### PR TITLE
Add support for discriminator identification for anyOf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fluent/bundle": "^0.19.1",
         "@hyperjump/browser": "^1.3.1",
+        "@hyperjump/json-pointer": "^1.1.1",
         "@hyperjump/json-schema": "^1.16.0",
         "@hyperjump/pact": "^1.4.0",
         "leven": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@fluent/bundle": "^0.19.1",
     "@hyperjump/browser": "^1.3.1",
+    "@hyperjump/json-pointer": "^1.1.1",
     "@hyperjump/json-schema": "^1.16.0",
     "@hyperjump/pact": "^1.4.0",
     "leven": "^4.0.0"

--- a/src/localization.js
+++ b/src/localization.js
@@ -259,4 +259,9 @@ export class Localization {
 
     return this._formatMessage("enum-error", formattedArgs);
   }
+
+  /** @type () => string */
+  getAnyOfErrorMessage() {
+    return this._formatMessage("anyOf-error");
+  }
 }

--- a/src/normalization-handlers/properties.js
+++ b/src/normalization-handlers/properties.js
@@ -1,5 +1,6 @@
-import { evaluateSchema } from "../normalized-output.js";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import * as JsonPointer from "@hyperjump/json-pointer";
+import { evaluateSchema } from "../normalized-output.js";
 
 /**
  * @import { KeywordHandler, NormalizedOutput } from "../index.d.ts"
@@ -15,10 +16,13 @@ const properties = {
     for (const propertyName in properties) {
       const propertyNode = Instance.step(propertyName, instance);
       if (!propertyNode) {
-        continue;
+        errors.push({
+          [JsonPointer.append(propertyName, Instance.uri(instance))]: {}
+        });
+      } else {
+        errors.push(evaluateSchema(properties[propertyName], propertyNode, context));
+        context.evaluatedProperties?.add(propertyName);
       }
-      errors.push(evaluateSchema(properties[propertyName], propertyNode, context));
-      context.evaluatedProperties?.add(propertyName);
     }
 
     return errors;

--- a/src/normalized-output.js
+++ b/src/normalized-output.js
@@ -85,8 +85,8 @@ export const evaluateSchema = (schemaLocation, instance, context) => {
 /** @type (a: API.NormalizedOutput, b: API.NormalizedOutput) => void */
 const mergeOutput = (a, b) => {
   for (const instanceLocation in b) {
+    a[instanceLocation] ??= {};
     for (const keywordUri in b[instanceLocation]) {
-      a[instanceLocation] ??= {};
       a[instanceLocation][keywordUri] ??= {};
 
       Object.assign(a[instanceLocation][keywordUri], b[instanceLocation][keywordUri]);

--- a/src/normalized-output.test.js
+++ b/src/normalized-output.test.js
@@ -138,6 +138,7 @@ describe("Error Output Normalization", async () => {
           "https://example.com/main#/type": true
         }
       },
+      "#/name": {},
       "#/age": {
         "https://json-schema.org/keyword/type": {
           "https://example.com/main#/properties/age/type": false
@@ -213,7 +214,8 @@ describe("Error Output Normalization", async () => {
         "https://json-schema.org/keyword/type": {
           "https://example.com/main#/$defs/profile/properties/name/type": false
         }
-      }
+      },
+      "#/profile/age": {}
     });
   });
 
@@ -313,7 +315,8 @@ describe("Error Output Normalization", async () => {
         "https://json-schema.org/keyword/type": {
           "https://example.com/main#/$defs/profile/properties/name/type": false
         }
-      }
+      },
+      "#/profile/age": {}
     });
   });
 

--- a/src/translations/en-US.ftl
+++ b/src/translations/en-US.ftl
@@ -1,32 +1,38 @@
+# Non-type specific messages
 type-error = The instance should be of type {$expected} but found {$actual}.
+const-error = The instance should be equal to {$expectedValue}.
+enum-error = { $variant ->
+	[suggestion] Unexpected value {$instanceValue}. Did you mean {$suggestion}?
+	*[fallback] Unexpected value {$instanceValue}. Expected one of: {$allowedValues}.
+}
 
+# String messages
 string-error = Expected a string {$constraints}.
 string-error-minLength = at least {$minLength} characters long
 string-error-maxLength = at most {$maxLength} characters long
+pattern-error = The instance should match the pattern: {$pattern}.
+format-error = The instance should match the format: {$format}.
 
+# Number messages
 number-error = Expected a number {$constraints}.
 number-error-minimum = greater than {$minimum}
 number-error-exclusive-minimum = greater than or equal to {$minimum}
 number-error-maximum = less than {$maximum}
 number-error-exclusive-maximum = less than or equal to {$maximum}
-
-required-error = This instance is missing required property(s): {$missingProperties}.
 multiple-of-error = The instance should be a multiple of {$divisor}.
 
+# Object messages
 properties-error = Expected object to have {$constraints}
 properties-error-max = at most {$maxProperties} properties.
 properties-error-min = at least {$minProperties} properties.
+required-error = This instance is missing required property(s): {$missingProperties}.
+additional-properties-error = The property "{$propertyName}" is not allowed.
 
-const-error = The instance should be equal to {$expectedValue}.
-
+# Array messages
 array-error = Expected the array to have {$constraints}.
 array-error-min = at least {$minItems} items
 array-error-max = at most {$maxItems} items
-
 unique-items-error = The instance should have unique items in the array.
-format-error = The instance should match the format: {$format}.
-pattern-error = The instance should match the pattern: {$pattern}.
-
 contains-error-min = The array must contain at least {$minContains -> 
   [one] item that passes
 	*[other] items that pass
@@ -36,9 +42,6 @@ contains-error-min-max = The array must contain at least {$minContains} and at m
 	*[other] items that pass
 } the 'contains' schema.
 
+# Conditional messages
+anyOf-error = The instance must pass at least one of the given schemas.
 not-error = The instance is not allowed to be used in this schema.
-additional-properties-error = The property "{$propertyName}" is not allowed.
-enum-error = { $variant ->
-	[suggestion] Unexpected value {$instanceValue}. Did you mean {$suggestion}?
-	*[fallback] Unexpected value {$instanceValue}. Expected one of: {$allowedValues}.
-}


### PR DESCRIPTION
I figured out a way to identify discriminators by adding nodes in the errorIndex for properties that don't exist in the instance. There's still a lot more to figure out, but this gets us passed one hurdle.