### PR TITLE
Updated README with installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,6 @@ It transforms standard, machine-oriented validation output into clear, human-fri
 
 
 > **Note:** This package is not yet published to npm. You can clone this repository locally to experiment with it:
-> ```bash
-> git clone https://github.com/hyperjump-io/better-json-schema-errors.git
-> ```
-> ```bash
-> cd better-json-schema-errors
-> ```
-> ```bash
-> npm install
-> ```
 > This project is currently a **work in progress** and will be published to npm once completed.
 
 


### PR DESCRIPTION
This PR updates the README to clarify that @hyperjump/better-json-schema-errors is not yet published to npm. It adds a short note below the installation command explaining that users can clone the repository locally to use the library, since it’s currently an in-progress project.

@jdesrosiers please check it out.