### PR TITLE
Remove unused plugin system with type errors

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-import { AST, EvaluationPlugin } from "@hyperjump/json-schema/experimental";
+import { AST } from "@hyperjump/json-schema/experimental";
 import { JsonNode } from "@hyperjump/json-schema/instance/experimental";
 import { Localization } from "./localization.js";
 
@@ -63,7 +63,6 @@ export type KeywordHandler = {
 export type EvaluationContext = {
   ast: AST;
   errorIndex: ErrorIndex;
-  plugins: EvaluationPlugin[];
 };
 
 export type ErrorIndex = {


### PR DESCRIPTION
After fixing some type errors in `@hyperjump/json-schema`, it exposed a type issue in the plugin system. We aren't using the plugin system, so I decided to just remove it for now instead of fix it. Something like it can be added in again later if it turns out we need it. Not sure why we added in the first place.