### PR TITLE
 fix messageParams values to strings

### DIFF
--- a/src/test-suite/tests/allOf.json
+++ b/src/test-suite/tests/allOf.json
@@ -16,7 +16,7 @@
         {
           "messageId": "minimum-message",
           "messageParams": {
-            "minimum": 3
+            "minimum": "3"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/allOf/1/minimum"]

--- a/src/test-suite/tests/const.json
+++ b/src/test-suite/tests/const.json
@@ -14,7 +14,7 @@
         {
           "messageId": "const-message",
           "messageParams": {
-            "expected": 42
+            "expected": "42"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/const"]

--- a/src/test-suite/tests/contains.json
+++ b/src/test-suite/tests/contains.json
@@ -14,7 +14,7 @@
         {
           "messageId": "contains-message",
           "messageParams": {
-            "minContains": 1
+            "minContains": "1"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/contains"]
@@ -33,7 +33,7 @@
         {
           "messageId": "contains-message",
           "messageParams": {
-            "minContains": 2
+            "minContains": "2"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/contains", "#/minContains"]
@@ -52,8 +52,8 @@
         {
           "messageId": "contains-exact-message",
           "messageParams": {
-            "minContains": 1,
-            "maxContains": 1
+            "minContains": "1",
+            "maxContains": "1"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/contains", "#/maxContains"]
@@ -72,8 +72,8 @@
         {
           "messageId": "contains-range-message",
           "messageParams": {
-            "minContains": 1,
-            "maxContains": 2
+            "minContains": "1",
+            "maxContains": "2"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/contains", "#/maxContains"]

--- a/src/test-suite/tests/dependentRequired.json
+++ b/src/test-suite/tests/dependentRequired.json
@@ -20,7 +20,7 @@
         {
           "messageId": "required-message",
           "messageParams": {
-            "count": 1,
+            "count": "1",
             "required": { "or": ["baz"] }
           },
           "instanceLocation": "#",

--- a/src/test-suite/tests/dependentSchemas.json
+++ b/src/test-suite/tests/dependentSchemas.json
@@ -20,7 +20,7 @@
         {
           "messageId": "required-message",
           "messageParams": {
-            "count": 1,
+            "count": "1",
             "required": { "or": ["baz"] }
           },
           "instanceLocation": "#",

--- a/src/test-suite/tests/else.json
+++ b/src/test-suite/tests/else.json
@@ -15,7 +15,7 @@
         {
           "messageId": "multipleOf-message",
           "messageParams": {
-            "multipleOf": 5
+            "multipleOf": "5"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/else/multipleOf"]

--- a/src/test-suite/tests/enum.json
+++ b/src/test-suite/tests/enum.json
@@ -14,7 +14,7 @@
           "messageId": "enum-message",
           "messageParams": {
             "expected": { "or": ["\"foo\"", "\"bar\""] },
-            "count": 2
+            "count": "2"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/enum"]

--- a/src/test-suite/tests/exclusiveMaximum.json
+++ b/src/test-suite/tests/exclusiveMaximum.json
@@ -13,7 +13,7 @@
         {
           "messageId": "exclusiveMaximum-message",
           "messageParams": {
-            "exclusiveMaximum": 3
+            "exclusiveMaximum": "3"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/exclusiveMaximum"]

--- a/src/test-suite/tests/exclusiveMinimum.json
+++ b/src/test-suite/tests/exclusiveMinimum.json
@@ -13,7 +13,7 @@
         {
           "messageId": "exclusiveMinimum-message",
           "messageParams": {
-            "exclusiveMinimum": 3
+            "exclusiveMinimum": "3"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/exclusiveMinimum"]

--- a/src/test-suite/tests/maxItems.json
+++ b/src/test-suite/tests/maxItems.json
@@ -13,7 +13,7 @@
         {
           "messageId": "maxItems-message",
           "messageParams": {
-            "maxItems": 1
+            "maxItems": "1"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/maxItems"]

--- a/src/test-suite/tests/maxLength.json
+++ b/src/test-suite/tests/maxLength.json
@@ -13,7 +13,7 @@
         {
           "messageId": "maxLength-message",
           "messageParams": {
-            "maxLength": 3
+            "maxLength": "3"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/maxLength"]

--- a/src/test-suite/tests/maxProperties.json
+++ b/src/test-suite/tests/maxProperties.json
@@ -13,7 +13,7 @@
         {
           "messageId": "maxProperties-message",
           "messageParams": {
-            "maxProperties": 1
+            "maxProperties": "1"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/maxProperties"]

--- a/src/test-suite/tests/maximum.json
+++ b/src/test-suite/tests/maximum.json
@@ -13,7 +13,7 @@
         {
           "messageId": "maximum-message",
           "messageParams": {
-            "maximum": 3
+            "maximum": "3"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/maximum"]

--- a/src/test-suite/tests/minItems.json
+++ b/src/test-suite/tests/minItems.json
@@ -13,7 +13,7 @@
         {
           "messageId": "minItems-message",
           "messageParams": {
-            "minItems": 1
+            "minItems": "1"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/minItems"]

--- a/src/test-suite/tests/minLength.json
+++ b/src/test-suite/tests/minLength.json
@@ -13,7 +13,7 @@
         {
           "messageId": "minLength-message",
           "messageParams": {
-            "minLength": 3
+            "minLength": "3"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/minLength"]

--- a/src/test-suite/tests/minProperties.json
+++ b/src/test-suite/tests/minProperties.json
@@ -13,7 +13,7 @@
         {
           "messageId": "minProperties-message",
           "messageParams": {
-            "minProperties": 2
+            "minProperties": "2"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/minProperties"]

--- a/src/test-suite/tests/minimum.json
+++ b/src/test-suite/tests/minimum.json
@@ -12,7 +12,7 @@
       "errors": [
         {
           "messageId": "minimum-message",
-          "messageParams": { "minimum": 3 },
+          "messageParams": { "minimum": "3" },
           "instanceLocation": "#",
           "schemaLocations": ["#/minimum"]
         }

--- a/src/test-suite/tests/multipleOf.json
+++ b/src/test-suite/tests/multipleOf.json
@@ -12,7 +12,7 @@
       "errors": [
         {
           "messageId": "multipleOf-message",
-          "messageParams": { "multipleOf": 3 },
+          "messageParams": { "multipleOf": "3" },
           "instanceLocation": "#",
           "schemaLocations": ["#/multipleOf"]
         }

--- a/src/test-suite/tests/oneOf.json
+++ b/src/test-suite/tests/oneOf.json
@@ -15,7 +15,7 @@
       "errors": [
         {
           "messageId": "oneOf-message",
-          "messageParams": { "matchCount": 0 },
+          "messageParams": { "matchCount": "0" },
           "alternatives": [
             [
               {
@@ -56,7 +56,7 @@
         {
           "messageId": "oneOf-message",
           "messageParams": {
-            "matchCount": 2
+            "matchCount": "2"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/oneOf"]

--- a/src/test-suite/tests/propertyNames.json
+++ b/src/test-suite/tests/propertyNames.json
@@ -14,7 +14,7 @@
         {
           "messageId": "minLength-message",
           "messageParams": {
-            "minLength": 5
+            "minLength": "5"
           },
           "instanceLocation": "#/foo",
           "schemaLocations": ["#/propertyNames/minLength"]
@@ -32,7 +32,7 @@
         {
           "messageId": "minLength-message",
           "messageParams": {
-            "minLength": 5
+            "minLength": "5"
           },
           "instanceLocation": "#/foo",
           "schemaLocations": ["#/propertyNames/minLength"]

--- a/src/test-suite/tests/required.json
+++ b/src/test-suite/tests/required.json
@@ -13,7 +13,7 @@
         {
           "messageId": "required-message",
           "messageParams": {
-            "count": 1,
+            "count": "1",
             "required": { "or": ["bar"] }
           },
           "instanceLocation": "#",

--- a/src/test-suite/tests/then.json
+++ b/src/test-suite/tests/then.json
@@ -13,7 +13,7 @@
         {
           "messageId": "multipleOf-message",
           "messageParams": {
-            "multipleOf": 5
+            "multipleOf": "5"
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/then/multipleOf"]


### PR DESCRIPTION
### PR Description
As per @jdesrosiers's suggestion I have converted `messageParams` values to strings in all of the test files.
discussed here: #119 

### Quick question
After converting `messageParams` values to strings  a few tests now produce different grammatical forms in the generated messages (e.g. plural vs singular).

This appears to be due to Fluent treating numeric values and string values differently for pluralization (e.g. `1` vs `"1"`), where `"1" `gives general plural message while `1` gives singular message. I’ve left localization behavior unchanged and wanted to confirm what should be done.
