### PR TITLE
Add support for draft-2019-09

### DIFF
--- a/src/hyperjump-json-schema.test.js
+++ b/src/hyperjump-json-schema.test.js
@@ -7,7 +7,6 @@ import {
   validate
 } from "@hyperjump/json-schema/draft-2020-12";
 import "@hyperjump/json-schema/draft-2019-09";
-
 import "@hyperjump/json-schema/formats";
 import { BASIC } from "@hyperjump/json-schema/experimental";
 import { jsonSchemaErrors } from "../src/index.js";

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { addErrorHandler, setNormalizationHandler } from "./json-schema-errors.js";
 
 // Normalization Handlers
+import additionalItemsNormalizationHandler from "./normalization-handlers/draft-04/additionalItems.js";
 import additionalPropertiesNormalizationHandler from "./normalization-handlers/additionalProperties.js";
 import allOfNormalizationHandler from "./normalization-handlers/allOf.js";
 import anyOfNormalizationHandler from "./normalization-handlers/anyOf.js";
@@ -16,6 +17,7 @@ import exclusiveMaximumNormalizationHandler from "./normalization-handlers/exclu
 import exclusiveMinimumNormalizationHandler from "./normalization-handlers/exclusiveMinimum.js";
 import formatNormalizationHandler from "./normalization-handlers/format.js";
 import ifNormalizationHandler from "./normalization-handlers/if.js";
+import itemsDraft04NormalizationHandler from "./normalization-handlers/draft-04/items.js";
 import itemsNormalizationHandler from "./normalization-handlers/items.js";
 import maximumNormalizationHandler from "./normalization-handlers/maximum.js";
 import maxContainsNormalizationHandler from "./normalization-handlers/maxContains.js";
@@ -44,9 +46,6 @@ import unevaluatedPropertiesNormalizationHandler from "./normalization-handlers/
 import uniqueItemsNormalizationHandler from "./normalization-handlers/uniqueItems.js";
 import unknownNormalizationHandler from "./normalization-handlers/unknown.js";
 
-import itemsDraft04NormalizationHandler from "./normalization-handlers/draft-04/items.js";
-import additionalItemsDraft04NormalizationHandler from "./normalization-handlers/draft-04/additionalItems.js";
-
 // Error Handlers
 import anyOfErrorHandler from "./error-handlers/anyOf.js";
 import booleanSchemaErrorHandler from "./error-handlers/boolean-schema.js";
@@ -74,6 +73,7 @@ import typeErrorHandler from "./error-handlers/type.js";
 import uniqueItemsErrorHandler from "./error-handlers/uniqueItems.js";
 import unknownErrorHandler from "./error-handlers/unknown.js";
 
+setNormalizationHandler("https://json-schema.org/keyword/draft-04/additionalItems", additionalItemsNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/additionalProperties", additionalPropertiesNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/allOf", allOfNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/anyOf", anyOfNormalizationHandler);
@@ -93,6 +93,7 @@ setNormalizationHandler("https://json-schema.org/keyword/draft-07/format", forma
 setNormalizationHandler("https://json-schema.org/keyword/draft-06/format", formatNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/draft-04/format", formatNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/if", ifNormalizationHandler);
+setNormalizationHandler("https://json-schema.org/keyword/draft-04/items", itemsDraft04NormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/items", itemsNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/exclusiveMaximum", exclusiveMaximumNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/exclusiveMinimum", exclusiveMinimumNormalizationHandler);
@@ -122,8 +123,6 @@ setNormalizationHandler("https://json-schema.org/keyword/unevaluatedItems", unev
 setNormalizationHandler("https://json-schema.org/keyword/unevaluatedProperties", unevaluatedPropertiesNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/uniqueItems", uniqueItemsNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/unknown", unknownNormalizationHandler);
-setNormalizationHandler("https://json-schema.org/keyword/draft-04/items", itemsDraft04NormalizationHandler);
-setNormalizationHandler("https://json-schema.org/keyword/draft-04/additionalItems", additionalItemsDraft04NormalizationHandler);
 
 addErrorHandler(anyOfErrorHandler);
 addErrorHandler(booleanSchemaErrorHandler);

--- a/src/normalization-handlers/draft-04/additionalItems.js
+++ b/src/normalization-handlers/draft-04/additionalItems.js
@@ -7,7 +7,7 @@ import * as Pact from "@hyperjump/pact";
  */
 
 /** @type NormalizationHandler<[number, string]> */
-const additionalItemsDraft04NormalizationHandler = {
+const additionalItemsNormalizationHandler = {
   evaluate([numberOfItems, additionalItems], instance, context) {
     /** @type NormalizedOutput[] */
     const outputs = [];
@@ -22,8 +22,7 @@ const additionalItemsDraft04NormalizationHandler = {
 
     return outputs;
   },
-
   simpleApplicator: true
 };
 
-export default additionalItemsDraft04NormalizationHandler;
+export default additionalItemsNormalizationHandler;

--- a/src/normalization-handlers/draft-04/items.js
+++ b/src/normalization-handlers/draft-04/items.js
@@ -15,22 +15,21 @@ const itemsDraft04NormalizationHandler = {
       return outputs;
     }
 
-    if (Array.isArray(items)) {
+    if (typeof items === "string") {
+      for (const itemNode of Instance.iter(instance)) {
+        outputs.push(evaluateSchema(items, itemNode, context));
+      }
+    } else {
       for (const [index, schemaLocation] of items.entries()) {
         const itemNode = Instance.step(String(index), instance);
         if (itemNode) {
           outputs.push(evaluateSchema(schemaLocation, itemNode, context));
         }
       }
-    } else {
-      for (const itemNode of Instance.iter(instance)) {
-        outputs.push(evaluateSchema(/** @type {string} */ (items), itemNode, context));
-      }
     }
 
     return outputs;
   },
-
   simpleApplicator: true
 };
 

--- a/src/test-suite/tests/items.json
+++ b/src/test-suite/tests/items.json
@@ -4,477 +4,126 @@
   "description": "The items keyword",
   "tests": [
     {
-      "description": "items (tuple validation) - draft 2019-09",
-      "compatibility": "<=2019",
+      "description": "all items",
       "schema": {
-        "type": "array",
-        "items": [
-          {
-            "type": "number"
-          }
-        ]
+        "items": { "type": "number" }
       },
-      "instance": [
-        "foo"
-      ],
+      "instance": [42, "foo"],
       "errors": [
         {
           "messageId": "type-message",
           "messageParams": {
-            "expectedTypes": {
-              "or": [
-                "number"
-              ]
-            }
-          },
-          "instanceLocation": "#/0",
-          "schemaLocations": [
-            "#/items/0/type"
-          ]
-        }
-      ]
-    },
-    {
-      "description": "items (tuple validation) with fewer items than defined - draft 2019-09",
-      "compatibility": "<=2019",
-      "schema": {
-        "items": [
-          {
-            "type": "number"
-          },
-          {
-            "type": "string"
-          }
-        ]
-      },
-      "instance": [
-        "foo"
-      ],
-      "errors": [
-        {
-          "messageId": "type-message",
-          "messageParams": {
-            "expectedTypes": {
-              "or": [
-                "number"
-              ]
-            }
-          },
-          "instanceLocation": "#/0",
-          "schemaLocations": [
-            "#/items/0/type"
-          ]
-        }
-      ]
-    },
-    {
-      "description": "items (tuple) on non-array - draft 2019-09",
-      "compatibility": "<=2019",
-      "schema": {
-        "items": [
-          {
-            "type": "number"
-          }
-        ]
-      },
-      "instance": 42,
-      "errors": []
-    },
-    {
-      "description": "items (as schema) applies to all - draft 2019-09",
-      "schema": {
-        "items": {
-          "type": "number"
-        }
-      },
-      "instance": [
-        42,
-        "foo"
-      ],
-      "errors": [
-        {
-          "messageId": "type-message",
-          "messageParams": {
-            "expectedTypes": {
-              "or": [
-                "number"
-              ]
-            }
+            "expectedTypes": { "or": ["number"] }
           },
           "instanceLocation": "#/1",
-          "schemaLocations": [
-            "#/items/type"
-          ]
+          "schemaLocations": ["#/items/type"]
         }
       ]
     },
     {
-      "description": "items (as schema) on non-array - draft 2019-09",
-      "compatibility": "<=2019",
-      "schema": {
-        "items": {
-          "type": "number"
-        }
-      },
-      "instance": 42,
-      "errors": []
-    },
-    {
-      "description": "items (tuple validation) with additionalItems false pass - draft 2019-09",
-      "compatibility": "<=2019",
-      "schema": {
-        "items": [
-          {
-            "type": "number"
-          }
-        ],
-        "additionalItems": false
-      },
-      "instance": [
-        42
-      ],
-      "errors": []
-    },
-    {
-      "description": "items (tuple validation) with additionalItems false fail - draft 2019-09",
-      "compatibility": "<=2019",
-      "schema": {
-        "items": [
-          {
-            "type": "number"
-          }
-        ],
-        "additionalItems": false
-      },
-      "instance": [
-        42,
-        "foo"
-      ],
-      "errors": [
-        {
-          "messageId": "boolean-schema-message",
-          "messageParams": {},
-          "instanceLocation": "#/1",
-          "schemaLocations": [
-            "#/additionalItems"
-          ]
-        }
-      ]
-    },
-    {
-      "description": "items (tuple validation) with additionalItems schema pass - draft 2019-09",
-      "compatibility": "<=2019",
-      "schema": {
-        "items": [
-          {
-            "type": "number"
-          }
-        ],
-        "additionalItems": {
-          "type": "string"
-        }
-      },
-      "instance": [
-        42,
-        "foo"
-      ],
-      "errors": []
-    },
-    {
-      "description": "items (tuple validation) with additionalItems schema fail - draft 2019-09",
-      "compatibility": "<=2019",
-      "schema": {
-        "items": [
-          {
-            "type": "number"
-          }
-        ],
-        "additionalItems": {
-          "type": "string"
-        }
-      },
-      "instance": [
-        42,
-        42
-      ],
-      "errors": [
-        {
-          "messageId": "type-message",
-          "messageParams": {
-            "expectedTypes": {
-              "or": [
-                "string"
-              ]
-            }
-          },
-          "instanceLocation": "#/1",
-          "schemaLocations": [
-            "#/additionalItems/type"
-          ]
-        }
-      ]
-    },
-    {
-      "description": "items (tuple) with additionalItems pass - draft 2019-09",
-      "compatibility": "<=2019",
-      "schema": {
-        "items": [
-          {
-            "type": "number"
-          }
-        ],
-        "additionalItems": {
-          "type": "string"
-        }
-      },
-      "instance": [
-        42,
-        "foo"
-      ],
-      "errors": []
-    },
-    {
-      "description": "items as a schema, additionalItems is ignored - draft 2019-09",
-      "schema": {
-        "items": {
-          "type": "number"
-        },
-        "additionalItems": false
-      },
-      "instance": [
-        42,
-        42
-      ],
-      "errors": []
-    },
-    {
-      "description": "items as an array, additionalItems fails for multiple items - draft 2019-09",
-      "compatibility": "<=2019",
-      "schema": {
-        "items": [
-          {
-            "type": "number"
-          }
-        ],
-        "additionalItems": {
-          "type": "string"
-        }
-      },
-      "instance": [
-        42,
-        42,
-        null
-      ],
-      "errors": [
-        {
-          "messageId": "type-message",
-          "messageParams": {
-            "expectedTypes": {
-              "or": [
-                "string"
-              ]
-            }
-          },
-          "instanceLocation": "#/1",
-          "schemaLocations": [
-            "#/additionalItems/type"
-          ]
-        },
-        {
-          "messageId": "type-message",
-          "messageParams": {
-            "expectedTypes": {
-              "or": [
-                "string"
-              ]
-            }
-          },
-          "instanceLocation": "#/2",
-          "schemaLocations": [
-            "#/additionalItems/type"
-          ]
-        }
-      ]
-    },
-    {
-      "description": "items as a schema, multiple items fail - draft 2019-09",
-      "compatibility": "<=2019",
-      "schema": {
-        "items": {
-          "type": "number"
-        }
-      },
-      "instance": [
-        "foo",
-        "bar"
-      ],
-      "errors": [
-        {
-          "messageId": "type-message",
-          "messageParams": {
-            "expectedTypes": {
-              "or": [
-                "number"
-              ]
-            }
-          },
-          "instanceLocation": "#/0",
-          "schemaLocations": [
-            "#/items/type"
-          ]
-        },
-        {
-          "messageId": "type-message",
-          "messageParams": {
-            "expectedTypes": {
-              "or": [
-                "number"
-              ]
-            }
-          },
-          "instanceLocation": "#/1",
-          "schemaLocations": [
-            "#/items/type"
-          ]
-        }
-      ]
-    },
-    {
-      "description": "items as a schema, instance is an empty array - draft 2019-09",
-      "compatibility": "<=2019",
-      "schema": {
-        "items": {
-          "type": "number"
-        }
-      },
-      "instance": [],
-      "errors": []
-    },
-    {
-      "description": "nested items and additionalItems - draft 2019-09",
-      "compatibility": "<=2019",
-      "schema": {
-        "items": [
-          {
-            "items": [
-              {
-                "type": "number"
-              }
-            ],
-            "additionalItems": false
-          }
-        ]
-      },
-      "instance": [
-        [
-          42,
-          "foo"
-        ]
-      ],
-      "errors": [
-        {
-          "messageId": "boolean-schema-message",
-          "messageParams": {},
-          "instanceLocation": "#/0/1",
-          "schemaLocations": [
-            "#/items/0/additionalItems"
-          ]
-        }
-      ]
-    },
-    {
-      "description": "items with false schema",
+      "description": "prefixItems/items with false schema",
       "compatibility": "2020",
       "schema": {
-        "prefixItems": [
-          {
-            "type": "number"
-          }
-        ],
+        "prefixItems": [{ "type": "number" }],
         "items": false
       },
-      "instance": [
-        42,
-        "foo"
-      ],
+      "instance": [42, "foo"],
       "errors": [
         {
           "messageId": "boolean-schema-message",
           "messageParams": {},
           "instanceLocation": "#/1",
-          "schemaLocations": [
-            "#/items"
-          ]
+          "schemaLocations": ["#/items"]
         }
       ]
     },
     {
-      "description": "items with object schema",
+      "description": "items/additionalItems with false schema",
+      "compatibility": "<=2019",
+      "schema": {
+        "items": [{ "type": "number" }],
+        "additionalItems": false
+      },
+      "instance": [42, "foo"],
+      "errors": [
+        {
+          "messageId": "boolean-schema-message",
+          "messageParams": {},
+          "instanceLocation": "#/1",
+          "schemaLocations": ["#/additionalItems"]
+        }
+      ]
+    },
+    {
+      "description": "prefix/items with object schema",
       "compatibility": "2020",
       "schema": {
-        "prefixItems": [
-          {
-            "type": "number"
-          }
-        ],
-        "items": {
-          "type": "string"
-        }
+        "prefixItems": [{ "type": "number" }],
+        "items": { "type": "string" }
       },
-      "instance": [
-        42,
-        null
-      ],
+      "instance": [42, null],
       "errors": [
         {
           "messageId": "type-message",
           "messageParams": {
-            "expectedTypes": {
-              "or": [
-                "string"
-              ]
-            }
+            "expectedTypes": { "or": ["string"] }
           },
           "instanceLocation": "#/1",
-          "schemaLocations": [
-            "#/items/type"
-          ]
+          "schemaLocations": ["#/items/type"]
+        }
+      ]
+    },
+    {
+      "description": "items/additionalItems with object schema",
+      "compatibility": "<=2019",
+      "schema": {
+        "items": [{ "type": "number" }],
+        "additionalItems": { "type": "string" }
+      },
+      "instance": [42, null],
+      "errors": [
+        {
+          "messageId": "type-message",
+          "messageParams": {
+            "expectedTypes": { "or": ["string"] }
+          },
+          "instanceLocation": "#/1",
+          "schemaLocations": ["#/additionalItems/type"]
         }
       ]
     },
     {
       "description": "items on a non-object",
-      "compatibility": "2020",
       "schema": {
-        "prefixItems": [
-          {
-            "type": "number"
-          }
-        ],
-        "items": {
-          "type": "string"
-        }
+        "items": { "type": "string" }
+      },
+      "instance": 42,
+      "errors": []
+    },
+    {
+      "description": "additionalItems on a non-array",
+      "compatibility": "<=2019",
+      "schema": {
+        "additionalItems": { "type": "string" }
       },
       "instance": 42,
       "errors": []
     },
     {
       "description": "items pass",
-      "compatibility": "2020",
       "schema": {
-        "prefixItems": [
-          {
-            "type": "number"
-          }
-        ],
-        "items": {
-          "type": "string"
-        }
+        "items": { "type": "number" }
       },
-      "instance": [
-        42,
-        "foo"
-      ],
+      "instance": [42, 24],
+      "errors": []
+    },
+    {
+      "description": "additionalItems pass",
+      "compatibility": "<=2019",
+      "schema": {
+        "additionalItems": { "type": "number" }
+      },
+      "instance": [42, 24],
       "errors": []
     }
   ]

--- a/src/test-suite/tests/prefixItems.json
+++ b/src/test-suite/tests/prefixItems.json
@@ -22,6 +22,24 @@
       ]
     },
     {
+      "description": "array-form items",
+      "compatibility": "<=2019",
+      "schema": {
+        "items": [{ "type": "number" }]
+      },
+      "instance": ["foo"],
+      "errors": [
+        {
+          "messageId": "type-message",
+          "messageParams": {
+            "expectedTypes": { "or": ["number"] }
+          },
+          "instanceLocation": "#/0",
+          "schemaLocations": ["#/items/0/type"]
+        }
+      ]
+    },
+    {
       "description": "prefixItems with fewer items than are defined",
       "compatibility": "2020",
       "schema": {
@@ -43,7 +61,28 @@
       ]
     },
     {
-      "description": "prefixItems on an non-object",
+      "description": "array-form items with fewer items than are defined",
+      "compatibility": "<=2019",
+      "schema": {
+        "items": [
+          { "type": "number" },
+          { "type": "string" }
+        ]
+      },
+      "instance": ["foo"],
+      "errors": [
+        {
+          "messageId": "type-message",
+          "messageParams": {
+            "expectedTypes": { "or": ["number"] }
+          },
+          "instanceLocation": "#/0",
+          "schemaLocations": ["#/items/0/type"]
+        }
+      ]
+    },
+    {
+      "description": "prefixItems on an non-array",
       "compatibility": "2020",
       "schema": {
         "prefixItems": [{ "type": "number" }]
@@ -52,9 +91,27 @@
       "errors": []
     },
     {
+      "description": "array-form items on an non-array",
+      "compatibility": "<=2019",
+      "schema": {
+        "items": [{ "type": "number" }]
+      },
+      "instance": 42,
+      "errors": []
+    },
+    {
       "description": "prefixItems pass",
       "schema": {
         "prefixItems": [{ "type": "number" }]
+      },
+      "instance": { "foo": 42 },
+      "errors": []
+    },
+    {
+      "description": "array-form items pass",
+      "compatibility": "<=2019",
+      "schema": {
+        "items": [{ "type": "number" }]
       },
       "instance": { "foo": 42 },
       "errors": []


### PR DESCRIPTION
@jdesrosiers 

### What’s included

 **New normalization handlers**

  * `items-draft04.js` — implements pre-2020 tuple validation semantics
  * `additionalItems-draft04.js` — implements legacy handling for items beyond the tuple
**Correct keyword registration**

* `https://json-schema.org/keyword/draft-04/items`
* `https://json-schema.org/keyword/draft-04/additionalItems`
* **New test coverage**

  * Added draft-2019-09 tests using `compatibility: "<=2019"`
  * Tests are mapped from existing `prefixItems` / `items` cases where behavior differs
 **No behavior changes** for draft-2020-12 or newer drafts

### Implementation details

* `items-draft04` mirrors the behavior of `prefixItems`:

  * Applies tuple validation by index
  * Calls `evaluateSchema` per array position
  * Always returns a `NormalizedOutput[]` (no `null` values)
* `additionalItems-draft04` mirrors the draft-2020-12 `items` handler:

  * Only applies when `items` is an array (tuple form)
  * Starts validating from `items.length`
  * Correctly handles `true`, `false`, and schema values
* Both handlers are implemented as **simple applicators**.

---

### Test status

All existing tests pass
New draft-2019-09 tests pass
Total: **200 / 200 tests passing**

---

### Notes

This implementation follows the guidance discussed in the issue:

* Explicit handlers for legacy semantics
* Test mapping approach instead of duplicating cases
* No localization changes required

Happy to adjust anything if you’d like a different structure or naming.
