### PR TITLE
Collapse maxProperties and minProperties error messages

### DIFF
--- a/src/error-handlers/maxProperties.js
+++ b/src/error-handlers/maxProperties.js
@@ -10,7 +10,8 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 const maxPropertiesErrorHandler = async (normalizedErrors, instance, localization) => {
   /** @type ErrorObject[] */
   const errors = [];
-
+  let lowestMaxProperties = Infinity;
+  let mostConstrainingLocation = null;
   for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/maxProperties"]) {
     if (normalizedErrors["https://json-schema.org/keyword/maxProperties"][schemaLocation]) {
       continue;
@@ -19,10 +20,16 @@ const maxPropertiesErrorHandler = async (normalizedErrors, instance, localizatio
     const keyword = await getSchema(schemaLocation);
     const maxProperties = /** @type number */ (Schema.value(keyword));
 
+    if (maxProperties < lowestMaxProperties) {
+      lowestMaxProperties = maxProperties;
+      mostConstrainingLocation = schemaLocation;
+    }
+  }
+  if (mostConstrainingLocation !== null) {
     errors.push({
-      message: localization.getMaxPropertiesErrorMessage(maxProperties),
+      message: localization.getMaxPropertiesErrorMessage(lowestMaxProperties),
       instanceLocation: Instance.uri(instance),
-      schemaLocations: [schemaLocation]
+      schemaLocations: [mostConstrainingLocation]
     });
   }
 

--- a/src/error-handlers/minProperties.js
+++ b/src/error-handlers/minProperties.js
@@ -11,6 +11,9 @@ const minPropertiesErrorHandler = async (normalizedErrors, instance, localizatio
   /** @type ErrorObject[] */
   const errors = [];
 
+  let highestMinProperties = -Infinity;
+  let mostConstrainingLocation = null;
+
   for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/minProperties"]) {
     if (normalizedErrors["https://json-schema.org/keyword/minProperties"][schemaLocation]) {
       continue;
@@ -19,10 +22,17 @@ const minPropertiesErrorHandler = async (normalizedErrors, instance, localizatio
     const keyword = await getSchema(schemaLocation);
     const minProperties = /** @type number */ (Schema.value(keyword));
 
+    if (minProperties > highestMinProperties) {
+      highestMinProperties = minProperties;
+      mostConstrainingLocation = schemaLocation;
+    }
+  }
+
+  if (mostConstrainingLocation !== null) {
     errors.push({
-      message: localization.getMinPropertiesErrorMessage(minProperties),
+      message: localization.getMinPropertiesErrorMessage(highestMinProperties),
       instanceLocation: Instance.uri(instance),
-      schemaLocations: [schemaLocation]
+      schemaLocations: [mostConstrainingLocation]
     });
   }
 

--- a/src/test-suite/tests/maxProperties.json
+++ b/src/test-suite/tests/maxProperties.json
@@ -27,6 +27,26 @@
       },
       "instance": { "foo": 1 },
       "errors": []
+    },
+    {
+      "description": "multiple maxProperties constraints (collapsed)",
+      "schema": {
+        "allOf": [
+          { "maxProperties": 2 },
+          { "maxProperties": 3 }
+        ]
+      },
+      "instance": { "a": 1, "b": 2, "c": 3, "d":4 },
+      "errors": [
+        {
+          "messageId": "maxProperties-message",
+          "messageParams": {
+            "maxProperties": "2"
+          },
+          "instanceLocation": "#",
+          "schemaLocations": ["#/allOf/0/maxProperties"]
+        }
+      ]
     }
   ]
 }

--- a/src/test-suite/tests/minProperties.json
+++ b/src/test-suite/tests/minProperties.json
@@ -27,6 +27,26 @@
       },
       "instance": { "foo": 42, "bar": true },
       "errors": []
+    },
+    {
+      "description": "multiple minProperties constraints (collapsed)",
+      "schema": {
+        "allOf": [
+          { "minProperties": 2 },
+          { "minProperties": 3 }
+        ]
+      },
+      "instance": { "a": 1 },
+      "errors": [
+        {
+          "messageId": "minProperties-message",
+          "messageParams": {
+            "minProperties": "3"
+          },
+          "instanceLocation": "#",
+          "schemaLocations": ["#/allOf/1/minProperties"]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description

When multiple maxProperties or minProperties constraints fail (e.g., via allOf), produce a single message with the most restrictive constraint instead of multiple redundant messages.

- ⁠maxProperties: use minimum value (tightest upper bound)
- minProperties: use maximum value (tightest lower bound)

- Fixes: #137

### Checklist

- [x] npm test
- [x] npm run lint
- [x] npm run type-check

### Additional Notes

#### Screenshot

<img width="670" height="130" alt="Screenshot 2026-01-27 at 2 19 27 AM" src="https://github.com/user-attachments/assets/9247bbb5-bf03-4f7e-865b-d704c3b10307" />
