### PR TITLE
Combine type error messages into a single meaningful error

### DIFF
--- a/src/error-handlers/type.js
+++ b/src/error-handlers/type.js
@@ -42,7 +42,7 @@ const typeErrorHandler = async (normalizedErrors, instance, localization) => {
 
     if (allowedTypes.size === 0) {
       errors.push({
-        message: localization.getUnknownErrorMessage("type"),
+        message: localization.getBooleanSchemaErrorMessage(),
         instanceLocation: Instance.uri(instance),
         schemaLocations: failedTypeLocations
       });

--- a/src/test-suite/tests/type.json
+++ b/src/test-suite/tests/type.json
@@ -41,9 +41,9 @@
       "description": "collapsed type errors",
       "schema": {
         "allOf": [
-          {"type": ["string","boolean","number"]},
-          {"type": ["string","number"]},
-          {"type": "string"}
+          { "type": ["string", "boolean", "number"] },
+          { "type": ["string", "number"] },
+          { "type": "string" }
         ]
       },
       "instance": null,
@@ -51,10 +51,27 @@
         {
           "messageId": "type-message",
           "messageParams": {
-            "expectedTypes": "string"
+            "expectedTypes": { "or": ["string"] }
           },
           "instanceLocation": "#",
           "schemaLocations": ["#/allOf/0/type", "#/allOf/1/type", "#/allOf/2/type"]
+        }
+      ]
+    },
+    {
+      "description": "no types allowed",
+      "schema": {
+        "allOf": [
+          { "type": "string" },
+          { "type": "number" }
+        ]
+      },
+      "instance": null,
+      "errors": [
+        {
+          "messageId": "boolean-schema-message",
+          "instanceLocation": "#",
+          "schemaLocations": ["#/allOf/0/type", "#/allOf/1/type"]
         }
       ]
     }


### PR DESCRIPTION
## Description
Fixes #133 

Currently, when multiple type keywords apply at the same instance location (e.g. through allOf), the validator emits multiple type error messages, which results in noisy output for users.

### Changes made
- Collect all failed type keyword locations
- Intersect allowed types across schemas
- Emit a single consolidated type error message
### Notes
- Treats integer as a subset of number during intersection
- Falls back to `getUnknownErrorMessage("type")` when no valid type remains