### PR TITLE
fix: use `vitest run` for test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "lint": "eslint src",
-    "test": "vitest --watch=false",
+    "test": "vitest run",
     "type-check": "tsc --noEmit",
     "docs": "typedoc --excludeExternals"
   },


### PR DESCRIPTION
Vitest v4+ no longer requires (and can conflict with) `--watch=false` in non-watch runs.

This updates the `test` script to use `vitest run`, which is the recommended
non-watch/CI mode and avoids CLI flag conflicts when users pass `--watch`.

No behavior change for CI or default test runs.
