### PR TITLE
Collapse maxLength and minLength error messages

### DIFF
--- a/src/error-handlers/maxLength.js
+++ b/src/error-handlers/maxLength.js
@@ -10,6 +10,8 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 const maxLengthErrorHandler = async (normalizedErrors, instance, localization) => {
   /** @type ErrorObject[] */
   const errors = [];
+  let lowestMaxLength = Infinity;
+  let mostConstrainingLocation = null;
 
   for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/maxLength"]) {
     if (normalizedErrors["https://json-schema.org/keyword/maxLength"][schemaLocation]) {
@@ -19,10 +21,16 @@ const maxLengthErrorHandler = async (normalizedErrors, instance, localization) =
     const keyword = await getSchema(schemaLocation);
     const maxLength = /** @type number */ (Schema.value(keyword));
 
+    if (maxLength < lowestMaxLength) {
+      lowestMaxLength = maxLength;
+      mostConstrainingLocation = schemaLocation;
+    }
+  }
+  if (mostConstrainingLocation !== null) {
     errors.push({
-      message: localization.getMaxLengthErrorMessage(maxLength),
+      message: localization.getMaxLengthErrorMessage(lowestMaxLength),
       instanceLocation: Instance.uri(instance),
-      schemaLocations: [schemaLocation]
+      schemaLocations: [mostConstrainingLocation]
     });
   }
 

--- a/src/error-handlers/minLength.js
+++ b/src/error-handlers/minLength.js
@@ -10,6 +10,8 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 const minLengthErrorHandler = async (normalizedErrors, instance, localization) => {
   /** @type ErrorObject[] */
   const errors = [];
+  let highestMinLength = -Infinity;
+  let mostConstrainingLocation = null;
 
   for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/minLength"]) {
     if (normalizedErrors["https://json-schema.org/keyword/minLength"][schemaLocation]) {
@@ -19,10 +21,16 @@ const minLengthErrorHandler = async (normalizedErrors, instance, localization) =
     const keyword = await getSchema(schemaLocation);
     const minLength = /** @type number */ (Schema.value(keyword));
 
+    if (minLength > highestMinLength) {
+      highestMinLength = minLength;
+      mostConstrainingLocation = schemaLocation;
+    }
+  }
+  if (mostConstrainingLocation !== null) {
     errors.push({
-      message: localization.getMinLengthErrorMessage(minLength),
+      message: localization.getMinLengthErrorMessage(highestMinLength),
       instanceLocation: Instance.uri(instance),
-      schemaLocations: [schemaLocation]
+      schemaLocations: [mostConstrainingLocation]
     });
   }
 

--- a/src/test-suite/tests/maxLength.json
+++ b/src/test-suite/tests/maxLength.json
@@ -27,6 +27,26 @@
       },
       "instance": "ab",
       "errors": []
+    },
+    {
+      "description": "multiple maxLength constraints (collapsed)",
+      "schema": {
+        "allOf": [
+          { "maxLength": 2 },
+          { "maxLength": 3 }
+        ]
+      },
+      "instance": "abcd",
+      "errors": [
+        {
+          "messageId": "maxLength-message",
+          "messageParams": {
+            "maxLength": "2"
+          },
+          "instanceLocation": "#",
+          "schemaLocations": ["#/allOf/0/maxLength"]
+        }
+      ]
     }
   ]
 }

--- a/src/test-suite/tests/minLength.json
+++ b/src/test-suite/tests/minLength.json
@@ -27,6 +27,26 @@
       },
       "instance": "abc",
       "errors": []
+    },
+    {
+      "description": "multiple minLength constraints (collapsed)",
+      "schema": {
+        "allOf": [
+          { "minLength": 2 },
+          { "minLength": 3 }
+        ]
+      },
+      "instance": "a",
+      "errors": [
+        {
+          "messageId": "minLength-message",
+          "messageParams": {
+            "minLength": "3"
+          },
+          "instanceLocation": "#",
+          "schemaLocations": ["#/allOf/1/minLength"]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description

When multiple maxLength or minLength constraints fail (e.g., via allOf), produce a single message with the most restrictive constraint instead of multiple redundant messages.

- ⁠⁠maxLength: use minimum value (tightest upper bound)
- ⁠minLength: use maximum value (tightest lower bound)
- Fixes: #138  

### Checklist

- [x] npm test
- [x] npm run lint
- [x] npm run type-check

### Additional Notes

#### Screenshot
<img width="656" height="122" alt="Screenshot 2026-01-28 at 11 20 34 AM" src="https://github.com/user-attachments/assets/c298eec6-3f44-4b13-8be0-78168f79d33a" />

