### PR TITLE
Add draft-06 contains support

### DIFF
--- a/src/error-handlers/contains.js
+++ b/src/error-handlers/contains.js
@@ -12,36 +12,43 @@ const containsErrorHandler = async (normalizedErrors, instance, localization) =>
   /** @type ErrorObject[] */
   const errors = [];
 
-  for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/contains"]) {
-    if (normalizedErrors["https://json-schema.org/keyword/contains"][schemaLocation] == true) {
-      continue;
+  const keywordUris = [
+    "https://json-schema.org/keyword/contains",
+    "https://json-schema.org/keyword/draft-06/contains"
+  ];
+
+  for (const keywordUri of keywordUris) {
+    for (const schemaLocation in normalizedErrors[keywordUri]) {
+      if (normalizedErrors[keywordUri][schemaLocation] == true) {
+        continue;
+      }
+
+      /** @type string[] */
+      const schemaLocations = [schemaLocation];
+
+      /** @type ContainsRange */
+      const range = {};
+
+      for (const minContainsLocation in normalizedErrors["https://json-schema.org/keyword/minContains"]) {
+        const minContainsNode = await getSchema(minContainsLocation);
+        const minContains = /** @type number */ (Schema.value(minContainsNode));
+        range.minContains = Math.max(range.minContains ?? -1, minContains);
+        schemaLocations.push(minContainsLocation);
+      }
+
+      for (const maxContainsLocation in normalizedErrors["https://json-schema.org/keyword/maxContains"]) {
+        const maxContainsNode = await getSchema(maxContainsLocation);
+        const maxContains = /** @type number */ (Schema.value(maxContainsNode));
+        range.maxContains = Math.min(range.maxContains ?? Number.MAX_VALUE, maxContains);
+        schemaLocations.push(maxContainsLocation);
+      }
+
+      errors.push({
+        message: localization.getContainsErrorMessage(range),
+        instanceLocation: Instance.uri(instance),
+        schemaLocations: schemaLocations
+      });
     }
-
-    /** @type string[] */
-    const schemaLocations = [schemaLocation];
-
-    /** @type ContainsRange */
-    const range = {};
-
-    for (const minContainsLocation in normalizedErrors["https://json-schema.org/keyword/minContains"]) {
-      const minContainsNode = await getSchema(minContainsLocation);
-      const minContains = /** @type number */ (Schema.value(minContainsNode));
-      range.minContains = Math.max(range.minContains ?? -1, minContains);
-      schemaLocations.push(minContainsLocation);
-    }
-
-    for (const maxContainsLocation in normalizedErrors["https://json-schema.org/keyword/maxContains"]) {
-      const maxContainsNode = await getSchema(maxContainsLocation);
-      const maxContains = /** @type number */ (Schema.value(maxContainsNode));
-      range.maxContains = Math.min(range.maxContains ?? Number.MAX_VALUE, maxContains);
-      schemaLocations.push(maxContainsLocation);
-    }
-
-    errors.push({
-      message: localization.getContainsErrorMessage(range),
-      instanceLocation: Instance.uri(instance),
-      schemaLocations: schemaLocations
-    });
   }
 
   return errors;

--- a/src/hyperjump-json-schema.test.js
+++ b/src/hyperjump-json-schema.test.js
@@ -7,6 +7,8 @@ import {
   validate
 } from "@hyperjump/json-schema/draft-2020-12";
 import "@hyperjump/json-schema/draft-2019-09";
+import "@hyperjump/json-schema/draft-07";
+import "@hyperjump/json-schema/draft-06";
 import "@hyperjump/json-schema/draft-04";
 import "@hyperjump/json-schema/formats";
 import { BASIC } from "@hyperjump/json-schema/experimental";
@@ -183,6 +185,6 @@ const getMessage = await (async function () {
 
 runTests("https://json-schema.org/draft/2020-12/schema", 2020);
 runTests("https://json-schema.org/draft/2019-09/schema", 2019);
-// runTests("http://json-schema.org/draft-07/schema", 7);
-// runTests("http://json-schema.org/draft-06/schema", 6);
+runTests("http://json-schema.org/draft-07/schema", 7);
+runTests("http://json-schema.org/draft-06/schema", 6);
 runTests("http://json-schema.org/draft-04/schema", 4);

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import allOfNormalizationHandler from "./normalization-handlers/allOf.js";
 import anyOfNormalizationHandler from "./normalization-handlers/anyOf.js";
 import constNormalizationHandler from "./normalization-handlers/const.js";
 import containsNormalizationHandler from "./normalization-handlers/contains.js";
+import containsDraft06NormalizationHandler from "./normalization-handlers/draft-06/contains.js";
 import definitionsNormalizationHandler from "./normalization-handlers/definitions.js";
 import dependenciesNormalizationHandler from "./normalization-handlers/draft-04/dependencies.js";
 import dependentRequiredNormalizationHandler from "./normalization-handlers/dependentRequired.js";
@@ -87,6 +88,7 @@ setNormalizationHandler("https://json-schema.org/keyword/allOf", allOfNormalizat
 setNormalizationHandler("https://json-schema.org/keyword/anyOf", anyOfNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/const", constNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/contains", containsNormalizationHandler);
+setNormalizationHandler("https://json-schema.org/keyword/draft-06/contains", containsDraft06NormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/definitions", definitionsNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/draft-04/dependencies", dependenciesNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/dependentRequired", dependentRequiredNormalizationHandler);

--- a/src/normalization-handlers/draft-06/contains.js
+++ b/src/normalization-handlers/draft-06/contains.js
@@ -1,0 +1,26 @@
+import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { evaluateSchema } from "../../json-schema-errors.js";
+
+/**
+ * @import { NormalizationHandler, NormalizedOutput } from "../../index.d.ts"
+ */
+
+/** @type NormalizationHandler<string> */
+const containsDraft06NormalizationHandler = {
+  evaluate(contains, instance, context) {
+    /** @type NormalizedOutput[] */
+    const output = [];
+
+    if (Instance.typeOf(instance) !== "array") {
+      return output;
+    }
+
+    for (const item of Instance.iter(instance)) {
+      output.push(evaluateSchema(contains, item, context));
+    }
+
+    return output;
+  }
+};
+
+export default containsDraft06NormalizationHandler;


### PR DESCRIPTION
Hi @jdesrosiers 

I made the required updates for draft-06/07 `contains` support:

Registered only the draft-06 keyword URI:
  https://json-schema.org/keyword/draft-06/contains
  (since draft-06 and draft-07 share the same keyword URI)

Added a draft-specific normalization handler at:
  src/normalization-handlers/draft-06/contains.js
  which implements the simpler draft-06 semantics (at least one matching item, no minContains/maxContains).

 Updated the shared error handler (src/error-handlers/contains.js) to treat
  `draft-06/contains` as a special case:
  - skips minContains/maxContains processing
  - always reports the default range `{ minContains: 1 }`

All tests are passing locally, and lint/type-check are clean.

Please let me know if anything else should be adjusted.
