### PR TITLE
Fix typo in sponsor url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "funding": {
     "type": "github",
-    "url": "https://github.com/sponsors/hyperump-io"
+    "url": "https://github.com/sponsors/hyperjump-io"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "*",


### PR DESCRIPTION
Corrected a minor typo in the sponsor URL under the funding section of package.json.