### PR TITLE
fix : multipleOf only considers case that fail in allOf

### DIFF
--- a/src/error-handlers/multipleOf.js
+++ b/src/error-handlers/multipleOf.js
@@ -15,10 +15,11 @@ const multipleOfErrorHandler = async (normalizedErrors, instance, localization) 
   let combinedMultipleOf = null;
   /** @type string[] */
   const schemaLocations = [];
+  let hasError = false;
 
   for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/multipleOf"]) {
-    if (normalizedErrors["https://json-schema.org/keyword/multipleOf"][schemaLocation]) {
-      continue;
+    if (!normalizedErrors["https://json-schema.org/keyword/multipleOf"][schemaLocation]) {
+      hasError = true;
     }
 
     const keyword = await getSchema(schemaLocation);
@@ -28,7 +29,7 @@ const multipleOfErrorHandler = async (normalizedErrors, instance, localization) 
     schemaLocations.push(schemaLocation);
   }
 
-  if (combinedMultipleOf !== null) {
+  if (combinedMultipleOf !== null && hasError) {
     errors.push({
       message: localization.getMultipleOfErrorMessage(combinedMultipleOf),
       instanceLocation: Instance.uri(instance),

--- a/src/test-suite/tests/multipleOf.json
+++ b/src/test-suite/tests/multipleOf.json
@@ -62,6 +62,26 @@
           "schemaLocations": ["#/allOf/0/multipleOf", "#/allOf/1/multipleOf"]
         }
       ]
+    },
+    {
+      "description": "multipleOf constraints within allOf are partially satisfied",
+      "schema": {
+        "allOf": [
+          { "multipleOf": 2 },
+          { "multipleOf": 3 }
+        ]
+      },
+      "instance": 9,
+      "errors": [
+        {
+          "messageId": "multipleOf-message",
+          "messageParams": {
+            "multipleOf": "6"
+          },
+          "instanceLocation": "#",
+          "schemaLocations": ["#/allOf/0/multipleOf", "#/allOf/1/multipleOf"]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## The issue
Currently, the `multipleOf` error handler only considers constraints that failed.

If a schema has many `multipleOf` constraints (e.g  in an allOf), such as:
```bash
{
  "allOf": [
    { "multipleOf": 2 },
    { "multipleOf": 3 }
  ]
}
```
```
instance = 9  //multiple of 3 only
```
then,
- multipleOf: 3 PASSES.
- multipleOf: 2 FAILS.
- The reported error is: "Expected a number that is a multiple of 2".
<img width="755" height="198" alt="Screenshot 2026-02-03 033257" src="https://github.com/user-attachments/assets/236aa9e5-1196-4d43-96bb-406aab7d7b9b" />

## Expected behaviour
since both are required, the user effectively requires a multiple of 6. The error message should reflect the combined constraint, `even if one of the individual checks passed`.

## The Fix
This PR updates `multipleOf` error-handler to:

- Iterate over all `multipleOf` constraints for the given location, regardless of whether they passed or failed.
- Calculate the LCM  of all these constraints.
- Report an error with the combined LCM value if at least one of the constraints failed.

## Verification
Test case has been added to cover this.