### PR TITLE
filter anyOf and oneOf alternative

### DIFF
--- a/src/error-handlers/anyOf.js
+++ b/src/error-handlers/anyOf.js
@@ -1,10 +1,9 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
-import * as JsonPointer from "@hyperjump/json-pointer";
 import * as Pact from "@hyperjump/pact";
 import { getErrors } from "../json-schema-errors.js";
 
 /**
- * @import { ErrorHandler, ErrorObject, NormalizedOutput } from "../index.d.ts"
+ * @import { ErrorHandler, ErrorObject, InstanceOutput } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
@@ -18,21 +17,20 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
       continue;
     }
 
+    const propertyLocations = Pact.pipe(
+      Instance.values(instance),
+      Pact.map(Instance.uri),
+      Pact.collectArray
+    );
+
+    const discriminators = propertyLocations.filter((propertyLocation) => {
+      return anyOf.some((alternative) => isPassingProperty(alternative[propertyLocation]));
+    });
+
+    /** @type ErrorObject[][] */
+    const alternatives = [];
     const instanceLocation = Instance.uri(instance);
 
-    const instanceProps = Pact.pipe(
-      Instance.keys(instance),
-      Pact.map((keyNode) => JsonPointer.append(/** @type {string} */ (Instance.value(keyNode)), instanceLocation)),
-      Pact.collectSet
-    );
-
-    const discriminators = Pact.pipe(
-      instanceProps,
-      Pact.filter((propLocation) => Pact.some((alternative) => propertyPasses(alternative[propLocation]), anyOf)),
-      Pact.collectSet
-    );
-
-    let filtered = [];
     for (const alternative of anyOf) {
       // Filter alternatives whose declared type doesn't match the instance type
       const typeResults = alternative[instanceLocation]?.["https://json-schema.org/keyword/type"];
@@ -41,35 +39,24 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
       }
 
       if (Instance.typeOf(instance) === "object") {
-        const declaredProps = Pact.pipe(
-          Object.keys(alternative),
-          Pact.filter((loc) => instanceProps.has(loc)),
-          Pact.collectSet
-        );
-
         // Filter alternative if it has no declared properties in common with the instance
-        if (!declaredProps.size) {
+        if (!propertyLocations.some((propertyLocation) => propertyLocation in alternative)) {
           continue;
         }
 
         // Filter alternative if it has failing properties that are declared and passing in another alternative
-        if (Pact.some((propLocation) => !propertyPasses(alternative[propLocation]), discriminators)) {
+        if (discriminators.some((propertyLocation) => !isPassingProperty(alternative[propertyLocation]))) {
           continue;
         }
       }
 
-      filtered.push(alternative);
+      // The alternative passed all the filters
+      alternatives.push(await getErrors(alternative, instance, localization));
     }
 
-    if (filtered.length === 0) {
-      filtered = anyOf;
-    }
-
-    /** @type ErrorObject[][] */
-    const alternatives = [];
-
+    // If all alternatives were filtered out, default to returning all of them
     if (alternatives.length === 0) {
-      for (const alternative of filtered) {
+      for (const alternative of anyOf) {
         alternatives.push(await getErrors(alternative, instance, localization));
       }
     }
@@ -89,12 +76,21 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
   return errors;
 };
 
-/** @type (propOutput: NormalizedOutput[string] | undefined) => boolean */
-const propertyPasses = (propOutput) => {
-  if (!propOutput) {
+/** @type (alternative: InstanceOutput | undefined) => boolean */
+const isPassingProperty = (propertyOutput) => {
+  if (!propertyOutput) {
     return false;
   }
-  return Object.values(propOutput).every((keywordResults) => Object.values(keywordResults).every((v) => v === true));
+
+  for (const keywordUri in propertyOutput) {
+    for (const schemaLocation in propertyOutput[keywordUri]) {
+      if (propertyOutput[keywordUri][schemaLocation] !== true) {
+        return false;
+      }
+    }
+  }
+
+  return true;
 };
 
 export default anyOfErrorHandler;

--- a/src/error-handlers/anyOf.js
+++ b/src/error-handlers/anyOf.js
@@ -86,10 +86,10 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
 
 /** @type (propOutput: NormalizedOutput[string] | undefined) => boolean */
 const propertyPasses = (propOutput) => {
-  if (!propOutput || Object.keys(propOutput).length === 0) return false;
-  return Object.values(propOutput).every((keywordResults) =>
-    Object.values(keywordResults).every((v) => v === true)
-  );
+  if (!propOutput || Object.keys(propOutput).length === 0) {
+    return false;
+  }
+  return Object.values(propOutput).every((keywordResults) => Object.values(keywordResults).every((v) => v === true));
 };
 
 export default anyOfErrorHandler;

--- a/src/error-handlers/anyOf.js
+++ b/src/error-handlers/anyOf.js
@@ -1,29 +1,19 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import * as JsonPointer from "@hyperjump/json-pointer";
+import * as Pact from "@hyperjump/pact";
 import { getErrors } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler, ErrorObject, NormalizedOutput } from "../index.d.ts"
  */
 
-/** @type (alternative: NormalizedOutput, propLocation: string) => boolean */
-const propertyPasses = (alternative, propLocation) => {
-  const propOutput = alternative[propLocation];
-  if (!propOutput || Object.keys(propOutput).length === 0) return false;
-  return Object.values(propOutput).every((keywordResults) =>
-    Object.values(keywordResults).every((v) => v === true)
-  );
-};
-
 /** @type ErrorHandler */
 const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
   /** @type ErrorObject[] */
   const errors = [];
 
-  for (const schemaLocation in normalizedErrors[
-    "https://json-schema.org/keyword/anyOf"
-  ]) {
-    const anyOf
-      = normalizedErrors["https://json-schema.org/keyword/anyOf"][schemaLocation];
+  for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/anyOf"]) {
+    const anyOf = normalizedErrors["https://json-schema.org/keyword/anyOf"][schemaLocation];
     if (typeof anyOf === "boolean") {
       continue;
     }
@@ -31,45 +21,47 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
     let filtered = anyOf;
 
     if (Instance.typeOf(instance) === "object") {
-      const instanceProps = new Set(
-        [...Instance.keys(instance)].map(
-          (keyNode) => /** @type {string} */ (Instance.value(keyNode))
+      const instanceProps = Pact.collectSet(
+        Pact.map(
+          (keyNode) => /** @type {string} */ (Instance.value(keyNode)),
+          Instance.keys(instance)
         )
       );
       const prefix = `${instanceLocation}/`;
 
-      filtered = filtered.filter((alternative) => {
+      filtered = [];
+      for (const alternative of anyOf) {
+        const typeResults = alternative[instanceLocation]?.["https://json-schema.org/keyword/type"];
+        if (typeResults && !Object.values(typeResults).every((isValid) => isValid)) {
+          continue;
+        }
+
         const declaredProps = Object.keys(alternative)
           .filter((loc) => loc.startsWith(prefix))
-          .map((loc) => loc.slice(prefix.length));
+          .map((loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1)))));
 
-        if (declaredProps.length === 0) return true;
-        return declaredProps.some((prop) => instanceProps.has(prop));
-      });
+        if (declaredProps.length > 0 && !declaredProps.some((prop) => instanceProps.has(prop))) {
+          continue;
+        }
 
-      filtered = filtered.filter((alternative) =>
-        [...instanceProps].some((prop) =>
-          propertyPasses(alternative, `${instanceLocation}/${prop}`)
-        )
-      );
+        if (!Pact.some((prop) => propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), instanceProps)) {
+          continue;
+        }
 
-      if (filtered.length === 0) {
-        filtered = anyOf;
+        filtered.push(alternative);
       }
     } else {
-      filtered = filtered.filter((alternative) => {
-        const typeResults
-          = alternative[instanceLocation]?.[
-            "https://json-schema.org/keyword/type"
-          ];
-        return (
-          !typeResults || Object.values(typeResults).every((isValid) => isValid)
-        );
-      });
-
-      if (filtered.length === 0) {
-        filtered = anyOf;
+      filtered = [];
+      for (const alternative of anyOf) {
+        const typeResults = alternative[instanceLocation]["https://json-schema.org/keyword/type"];
+        if (!typeResults || Object.values(typeResults).every((isValid) => isValid)) {
+          filtered.push(alternative);
+        }
       }
+    }
+
+    if (filtered.length === 0) {
+      filtered = anyOf;
     }
 
     const alternatives = [];
@@ -90,6 +82,14 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
   }
 
   return errors;
+};
+
+/** @type (propOutput: NormalizedOutput[string] | undefined) => boolean */
+const propertyPasses = (propOutput) => {
+  if (!propOutput || Object.keys(propOutput).length === 0) return false;
+  return Object.values(propOutput).every((keywordResults) =>
+    Object.values(keywordResults).every((v) => v === true)
+  );
 };
 
 export default anyOfErrorHandler;

--- a/src/error-handlers/anyOf.js
+++ b/src/error-handlers/anyOf.js
@@ -2,36 +2,79 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 import { getErrors } from "../json-schema-errors.js";
 
 /**
- * @import { ErrorHandler, ErrorObject } from "../index.d.ts"
+ * @import { ErrorHandler, ErrorObject, NormalizedOutput } from "../index.d.ts"
  */
+
+/** @type (alternative: NormalizedOutput, propLocation: string) => boolean */
+const propertyPasses = (alternative, propLocation) => {
+  const propOutput = alternative[propLocation];
+  if (!propOutput || Object.keys(propOutput).length === 0) return false;
+  return Object.values(propOutput).every((keywordResults) =>
+    Object.values(keywordResults).every((v) => v === true)
+  );
+};
 
 /** @type ErrorHandler */
 const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
   /** @type ErrorObject[] */
   const errors = [];
 
-  for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/anyOf"]) {
-    const anyOf = normalizedErrors["https://json-schema.org/keyword/anyOf"][schemaLocation];
+  for (const schemaLocation in normalizedErrors[
+    "https://json-schema.org/keyword/anyOf"
+  ]) {
+    const anyOf
+      = normalizedErrors["https://json-schema.org/keyword/anyOf"][schemaLocation];
     if (typeof anyOf === "boolean") {
       continue;
     }
-
-    const alternatives = [];
     const instanceLocation = Instance.uri(instance);
+    let filtered = anyOf;
 
-    for (const alternative of anyOf) {
-      const typeErrors = alternative[instanceLocation]?.["https://json-schema.org/keyword/type"];
-      const match = !typeErrors || Object.values(typeErrors).every((isValid) => isValid);
+    if (Instance.typeOf(instance) === "object") {
+      const instanceProps = new Set(
+        [...Instance.keys(instance)].map(
+          (keyNode) => /** @type {string} */ (Instance.value(keyNode))
+        )
+      );
+      const prefix = `${instanceLocation}/`;
 
-      if (match) {
-        alternatives.push(await getErrors(alternative, instance, localization));
+      filtered = filtered.filter((alternative) => {
+        const declaredProps = Object.keys(alternative)
+          .filter((loc) => loc.startsWith(prefix))
+          .map((loc) => loc.slice(prefix.length));
+
+        if (declaredProps.length === 0) return true;
+        return declaredProps.some((prop) => instanceProps.has(prop));
+      });
+
+      filtered = filtered.filter((alternative) =>
+        [...instanceProps].some((prop) =>
+          propertyPasses(alternative, `${instanceLocation}/${prop}`)
+        )
+      );
+
+      if (filtered.length === 0) {
+        filtered = anyOf;
+      }
+    } else {
+      filtered = filtered.filter((alternative) => {
+        const typeResults
+          = alternative[instanceLocation]?.[
+            "https://json-schema.org/keyword/type"
+          ];
+        return (
+          !typeResults || Object.values(typeResults).every((isValid) => isValid)
+        );
+      });
+
+      if (filtered.length === 0) {
+        filtered = anyOf;
       }
     }
 
-    if (alternatives.length === 0) {
-      for (const alternative of anyOf) {
-        alternatives.push(await getErrors(alternative, instance, localization));
-      }
+    const alternatives = [];
+    for (const alternative of filtered) {
+      alternatives.push(await getErrors(alternative, instance, localization));
     }
 
     if (alternatives.length === 1) {
@@ -40,7 +83,7 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
       errors.push({
         message: localization.getAnyOfErrorMessage(),
         alternatives: alternatives,
-        instanceLocation: Instance.uri(instance),
+        instanceLocation,
         schemaLocations: [schemaLocation]
       });
     }

--- a/src/error-handlers/anyOf.js
+++ b/src/error-handlers/anyOf.js
@@ -17,13 +17,16 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
     if (typeof anyOf === "boolean") {
       continue;
     }
+
     const instanceLocation = Instance.uri(instance);
     let filtered = anyOf;
 
     const isObject = Instance.typeOf(instance) === "object";
-    const instanceProps = isObject
-      ? Pact.collectSet(Pact.pipe(Instance.keys(instance), Pact.map((keyNode) => /** @type {string} */ (Instance.value(keyNode)))))
-      : undefined;
+    const instanceProps = Pact.pipe(
+      Instance.keys(instance),
+      Pact.map((keyNode) => /** @type {string} */ (Instance.value(keyNode))),
+      Pact.collectSet
+    );
     const prefix = `${instanceLocation}/`;
 
     filtered = [];
@@ -34,11 +37,12 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
       }
 
       if (isObject) {
-        const declaredProps = Pact.collectSet(Pact.pipe(
+        const declaredProps = Pact.pipe(
           Object.keys(alternative),
           Pact.filter((loc) => loc.startsWith(prefix)),
-          Pact.map((loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1)))))
-        ));
+          Pact.map((loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1))))),
+          Pact.collectSet
+        );
 
         if (declaredProps.size > 0 && !Pact.some((prop) => declaredProps.has(prop), /** @type {Set<string>} */ (instanceProps))) {
           continue;
@@ -56,15 +60,13 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
     const alternatives = [];
 
     if (isObject) {
-      const discriminators = Pact.collectSet(
-        /** @type {Iterable<string>} */ (Pact.pipe(
-          filtered,
-          Pact.map((alternative) => Pact.pipe(
-            /** @type {Set<string>} */ (instanceProps),
-            Pact.filter((prop) => propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]))
-          )),
-          Pact.flatten
-        ))
+      const discriminators = Pact.pipe(
+        instanceProps,
+        Pact.filter((prop) => {
+          const propLocation = JsonPointer.append(prop, instanceLocation);
+          return Pact.some((alternative) => propertyPasses(alternative[propLocation]), filtered);
+        }),
+        Pact.collectSet
       );
 
       for (const alternative of filtered) {

--- a/src/error-handlers/anyOf.js
+++ b/src/error-handlers/anyOf.js
@@ -19,26 +19,20 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
     }
 
     const instanceLocation = Instance.uri(instance);
-    let filtered = anyOf;
 
     const instanceProps = Pact.pipe(
       Instance.keys(instance),
-      Pact.map((keyNode) => /** @type {string} */ (Instance.value(keyNode))),
+      Pact.map((keyNode) => JsonPointer.append(/** @type {string} */ (Instance.value(keyNode)), instanceLocation)),
       Pact.collectSet
     );
 
     const discriminators = Pact.pipe(
       instanceProps,
-      Pact.filter((prop) => {
-        const propLocation = JsonPointer.append(prop, instanceLocation);
-        return Pact.some((alternative) => propertyPasses(alternative[propLocation]), anyOf);
-      }),
+      Pact.filter((propLocation) => Pact.some((alternative) => propertyPasses(alternative[propLocation]), anyOf)),
       Pact.collectSet
     );
 
-    const prefix = `${instanceLocation}/`;
-
-    filtered = [];
+    let filtered = [];
     for (const alternative of anyOf) {
       // Filter alternatives whose declared type doesn't match the instance type
       const typeResults = alternative[instanceLocation]?.["https://json-schema.org/keyword/type"];
@@ -49,18 +43,17 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
       if (Instance.typeOf(instance) === "object") {
         const declaredProps = Pact.pipe(
           Object.keys(alternative),
-          Pact.filter((loc) => loc.startsWith(prefix)),
-          Pact.map((loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1))))),
+          Pact.filter((loc) => instanceProps.has(loc)),
           Pact.collectSet
         );
 
         // Filter alternative if it has no declared properties in common with the instance
-        if (!Pact.some((prop) => declaredProps.has(prop), instanceProps)) {
+        if (!declaredProps.size) {
           continue;
         }
 
-        // Filter alternative if it has failing properties that are decalred and passing in another alternative
-        if (Pact.some((prop) => !propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), discriminators)) {
+        // Filter alternative if it has failing properties that are declared and passing in another alternative
+        if (Pact.some((propLocation) => !propertyPasses(alternative[propLocation]), discriminators)) {
           continue;
         }
       }

--- a/src/error-handlers/anyOf.js
+++ b/src/error-handlers/anyOf.js
@@ -21,22 +21,32 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
     const instanceLocation = Instance.uri(instance);
     let filtered = anyOf;
 
-    const isObject = Instance.typeOf(instance) === "object";
     const instanceProps = Pact.pipe(
       Instance.keys(instance),
       Pact.map((keyNode) => /** @type {string} */ (Instance.value(keyNode))),
       Pact.collectSet
     );
+
+    const discriminators = Pact.pipe(
+      instanceProps,
+      Pact.filter((prop) => {
+        const propLocation = JsonPointer.append(prop, instanceLocation);
+        return Pact.some((alternative) => propertyPasses(alternative[propLocation]), anyOf);
+      }),
+      Pact.collectSet
+    );
+
     const prefix = `${instanceLocation}/`;
 
     filtered = [];
     for (const alternative of anyOf) {
+      // Filter alternatives whose declared type doesn't match the instance type
       const typeResults = alternative[instanceLocation]?.["https://json-schema.org/keyword/type"];
       if (typeResults && !Object.values(typeResults).every((isValid) => isValid)) {
         continue;
       }
 
-      if (isObject) {
+      if (Instance.typeOf(instance) === "object") {
         const declaredProps = Pact.pipe(
           Object.keys(alternative),
           Pact.filter((loc) => loc.startsWith(prefix)),
@@ -44,7 +54,13 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
           Pact.collectSet
         );
 
-        if (declaredProps.size > 0 && !Pact.some((prop) => declaredProps.has(prop), /** @type {Set<string>} */ (instanceProps))) {
+        // Filter alternative if it has no declared properties in common with the instance
+        if (!Pact.some((prop) => declaredProps.has(prop), instanceProps)) {
+          continue;
+        }
+
+        // Filter alternative if it has failing properties that are decalred and passing in another alternative
+        if (Pact.some((prop) => !propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), discriminators)) {
           continue;
         }
       }
@@ -58,23 +74,6 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
 
     /** @type ErrorObject[][] */
     const alternatives = [];
-
-    if (isObject) {
-      const discriminators = Pact.pipe(
-        instanceProps,
-        Pact.filter((prop) => {
-          const propLocation = JsonPointer.append(prop, instanceLocation);
-          return Pact.some((alternative) => propertyPasses(alternative[propLocation]), filtered);
-        }),
-        Pact.collectSet
-      );
-
-      for (const alternative of filtered) {
-        if (!Pact.some((prop) => !propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), discriminators)) {
-          alternatives.push(await getErrors(alternative, instance, localization));
-        }
-      }
-    }
 
     if (alternatives.length === 0) {
       for (const alternative of filtered) {

--- a/src/error-handlers/anyOf.js
+++ b/src/error-handlers/anyOf.js
@@ -20,48 +20,55 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
     const instanceLocation = Instance.uri(instance);
     let filtered = anyOf;
 
-    if (Instance.typeOf(instance) === "object") {
-      const instanceProps = Pact.collectSet(
-        Pact.map(
-          (keyNode) => /** @type {string} */ (Instance.value(keyNode)),
-          Instance.keys(instance)
-        )
-      );
-      const prefix = `${instanceLocation}/`;
+    const isObject = Instance.typeOf(instance) === "object";
+    const instanceProps = isObject
+      ? Pact.collectSet(Pact.map((keyNode) => /** @type {string} */ (Instance.value(keyNode)), Instance.keys(instance)))
+      : undefined;
+    const prefix = `${instanceLocation}/`;
 
-      filtered = [];
-      for (const alternative of anyOf) {
-        const typeResults = alternative[instanceLocation]?.["https://json-schema.org/keyword/type"];
-        if (typeResults && !Object.values(typeResults).every((isValid) => isValid)) {
-          continue;
-        }
-
-        const declaredProps = Object.keys(alternative)
-          .filter((loc) => loc.startsWith(prefix))
-          .map((loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1)))));
-
-        if (declaredProps.length > 0 && !declaredProps.some((prop) => instanceProps.has(prop))) {
-          continue;
-        }
-
-        if (!Pact.some((prop) => propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), instanceProps)) {
-          continue;
-        }
-
-        filtered.push(alternative);
+    filtered = [];
+    for (const alternative of anyOf) {
+      const typeResults = alternative[instanceLocation]?.["https://json-schema.org/keyword/type"];
+      if (typeResults && !Object.values(typeResults).every((isValid) => isValid)) {
+        continue;
       }
-    } else {
-      filtered = [];
-      for (const alternative of anyOf) {
-        const typeResults = alternative[instanceLocation]["https://json-schema.org/keyword/type"];
-        if (!typeResults || Object.values(typeResults).every((isValid) => isValid)) {
-          filtered.push(alternative);
+
+      if (isObject) {
+        const declaredProps = Pact.map(
+          (loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1)))),
+          Pact.filter((loc) => loc.startsWith(prefix), Object.keys(alternative))
+        );
+
+        let hasDeclaredProps = false;
+        const hasMatchingProp = Pact.some((prop) => {
+          hasDeclaredProps = true;
+          return /** @type {Set<string>} */ (instanceProps).has(prop);
+        }, declaredProps);
+        if (hasDeclaredProps && !hasMatchingProp) {
+          continue;
         }
       }
+
+      filtered.push(alternative);
     }
 
     if (filtered.length === 0) {
       filtered = anyOf;
+    }
+
+    if (isObject) {
+      const discriminators = Pact.collectSet(
+        Pact.filter(
+          (prop) => Pact.some((alternative) => propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), filtered),
+          /** @type {Set<string>} */ (instanceProps)
+        )
+      );
+
+      const afterRule2 = Pact.collectArray(Pact.filter((alternative) => !Pact.some((prop) => !propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), discriminators), filtered));
+
+      if (afterRule2.length > 0) {
+        filtered = afterRule2;
+      }
     }
 
     const alternatives = [];
@@ -86,7 +93,7 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
 
 /** @type (propOutput: NormalizedOutput[string] | undefined) => boolean */
 const propertyPasses = (propOutput) => {
-  if (!propOutput || Object.keys(propOutput).length === 0) {
+  if (!propOutput) {
     return false;
   }
   return Object.values(propOutput).every((keywordResults) => Object.values(keywordResults).every((v) => v === true));

--- a/src/error-handlers/anyOf.js
+++ b/src/error-handlers/anyOf.js
@@ -22,7 +22,7 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
 
     const isObject = Instance.typeOf(instance) === "object";
     const instanceProps = isObject
-      ? Pact.collectSet(Pact.map((keyNode) => /** @type {string} */ (Instance.value(keyNode)), Instance.keys(instance)))
+      ? Pact.collectSet(Pact.pipe(Instance.keys(instance), Pact.map((keyNode) => /** @type {string} */ (Instance.value(keyNode)))))
       : undefined;
     const prefix = `${instanceLocation}/`;
 
@@ -34,17 +34,13 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
       }
 
       if (isObject) {
-        const declaredProps = Pact.map(
-          (loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1)))),
-          Pact.filter((loc) => loc.startsWith(prefix), Object.keys(alternative))
-        );
+        const declaredProps = Pact.collectSet(Pact.pipe(
+          Object.keys(alternative),
+          Pact.filter((loc) => loc.startsWith(prefix)),
+          Pact.map((loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1)))))
+        ));
 
-        let hasDeclaredProps = false;
-        const hasMatchingProp = Pact.some((prop) => {
-          hasDeclaredProps = true;
-          return /** @type {Set<string>} */ (instanceProps).has(prop);
-        }, declaredProps);
-        if (hasDeclaredProps && !hasMatchingProp) {
+        if (declaredProps.size > 0 && !Pact.some((prop) => declaredProps.has(prop), /** @type {Set<string>} */ (instanceProps))) {
           continue;
         }
       }
@@ -56,24 +52,32 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
       filtered = anyOf;
     }
 
+    /** @type ErrorObject[][] */
+    const alternatives = [];
+
     if (isObject) {
       const discriminators = Pact.collectSet(
-        Pact.filter(
-          (prop) => Pact.some((alternative) => propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), filtered),
-          /** @type {Set<string>} */ (instanceProps)
-        )
+        /** @type {Iterable<string>} */ (Pact.pipe(
+          filtered,
+          Pact.map((alternative) => Pact.pipe(
+            /** @type {Set<string>} */ (instanceProps),
+            Pact.filter((prop) => propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]))
+          )),
+          Pact.flatten
+        ))
       );
 
-      const afterRule2 = Pact.collectArray(Pact.filter((alternative) => !Pact.some((prop) => !propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), discriminators), filtered));
-
-      if (afterRule2.length > 0) {
-        filtered = afterRule2;
+      for (const alternative of filtered) {
+        if (!Pact.some((prop) => !propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), discriminators)) {
+          alternatives.push(await getErrors(alternative, instance, localization));
+        }
       }
     }
 
-    const alternatives = [];
-    for (const alternative of filtered) {
-      alternatives.push(await getErrors(alternative, instance, localization));
+    if (alternatives.length === 0) {
+      for (const alternative of filtered) {
+        alternatives.push(await getErrors(alternative, instance, localization));
+      }
     }
 
     if (alternatives.length === 1) {
@@ -81,7 +85,7 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
     } else {
       errors.push({
         message: localization.getAnyOfErrorMessage(),
-        alternatives: alternatives,
+        alternatives,
         instanceLocation,
         schemaLocations: [schemaLocation]
       });

--- a/src/error-handlers/oneOf.js
+++ b/src/error-handlers/oneOf.js
@@ -1,29 +1,19 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import * as JsonPointer from "@hyperjump/json-pointer";
+import * as Pact from "@hyperjump/pact";
 import { getErrors } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler, ErrorObject, NormalizedOutput } from "../index.d.ts"
  */
 
-/** @type (alternative: NormalizedOutput, propLocation: string) => boolean */
-const propertyPasses = (alternative, propLocation) => {
-  const propOutput = alternative[propLocation];
-  if (!propOutput || Object.keys(propOutput).length === 0) return false;
-  return Object.values(propOutput).every((keywordResults) =>
-    Object.values(keywordResults).every((v) => v === true)
-  );
-};
-
 /** @type ErrorHandler */
 const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
   /** @type ErrorObject[] */
   const errors = [];
 
-  for (const schemaLocation in normalizedErrors[
-    "https://json-schema.org/keyword/oneOf"
-  ]) {
-    const oneOf
-      = normalizedErrors["https://json-schema.org/keyword/oneOf"][schemaLocation];
+  for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/oneOf"]) {
+    const oneOf = normalizedErrors["https://json-schema.org/keyword/oneOf"][schemaLocation];
     if (typeof oneOf === "boolean") {
       continue;
     }
@@ -35,11 +25,7 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
     const failingAlternatives = [];
 
     for (const alternative of oneOf) {
-      const alternativeErrors = await getErrors(
-        alternative,
-        instance,
-        localization
-      );
+      const alternativeErrors = await getErrors(alternative, instance, localization);
       if (alternativeErrors.length) {
         failingAlternatives.push(alternativeErrors);
       } else {
@@ -64,54 +50,52 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
     let filtered = oneOf;
 
     if (Instance.typeOf(instance) === "object") {
-      const instanceProps = new Set(
-        [...Instance.keys(instance)].map(
-          (keyNode) => /** @type {string} */ (Instance.value(keyNode))
+      const instanceProps = Pact.collectSet(
+        Pact.map(
+          (keyNode) => /** @type {string} */ (Instance.value(keyNode)),
+          Instance.keys(instance)
         )
       );
       const prefix = `${instanceLocation}/`;
 
-      filtered = filtered.filter((alternative) => {
+      filtered = [];
+      for (const alternative of oneOf) {
+        const typeResults = alternative[instanceLocation]?.["https://json-schema.org/keyword/type"];
+        if (typeResults && !Object.values(typeResults).every((isValid) => isValid)) {
+          continue;
+        }
+
         const declaredProps = Object.keys(alternative)
           .filter((loc) => loc.startsWith(prefix))
-          .map((loc) => loc.slice(prefix.length));
+          .map((loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1)))));
 
-        if (declaredProps.length === 0) return true;
-        return declaredProps.some((prop) => instanceProps.has(prop));
-      });
+        if (declaredProps.length > 0 && !declaredProps.some((prop) => instanceProps.has(prop))) {
+          continue;
+        }
 
-      filtered = filtered.filter((alternative) =>
-        [...instanceProps].some((prop) =>
-          propertyPasses(alternative, `${instanceLocation}/${prop}`)
-        )
-      );
+        if (!Pact.some((prop) => propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), instanceProps)) {
+          continue;
+        }
 
-      if (filtered.length === 0) {
-        filtered = oneOf;
+        filtered.push(alternative);
       }
     } else {
-      filtered = filtered.filter((alternative) => {
-        const typeResults
-          = alternative[instanceLocation]?.[
-            "https://json-schema.org/keyword/type"
-          ];
-        return (
-          !typeResults || Object.values(typeResults).every((isValid) => isValid)
-        );
-      });
-
-      if (filtered.length === 0) {
-        filtered = oneOf;
+      filtered = [];
+      for (const alternative of oneOf) {
+        const typeResults = alternative[instanceLocation]["https://json-schema.org/keyword/type"];
+        if (!typeResults || Object.values(typeResults).every((isValid) => isValid)) {
+          filtered.push(alternative);
+        }
       }
+    }
+
+    if (filtered.length === 0) {
+      filtered = oneOf;
     }
 
     const alternatives = [];
     for (const alternative of filtered) {
-      const alternativeErrors = await getErrors(
-        alternative,
-        instance,
-        localization
-      );
+      const alternativeErrors = await getErrors(alternative, instance, localization);
       if (alternativeErrors.length) {
         alternatives.push(alternativeErrors);
       }
@@ -134,6 +118,14 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
   }
 
   return errors;
+};
+
+/** @type (propOutput: NormalizedOutput[string] | undefined) => boolean */
+const propertyPasses = (propOutput) => {
+  if (!propOutput || Object.keys(propOutput).length === 0) return false;
+  return Object.values(propOutput).every((keywordResults) =>
+    Object.values(keywordResults).every((v) => v === true)
+  );
 };
 
 export default oneOfErrorHandler;

--- a/src/error-handlers/oneOf.js
+++ b/src/error-handlers/oneOf.js
@@ -1,10 +1,9 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
-import * as JsonPointer from "@hyperjump/json-pointer";
 import * as Pact from "@hyperjump/pact";
 import { getErrors } from "../json-schema-errors.js";
 
 /**
- * @import { ErrorHandler, ErrorObject, NormalizedOutput } from "../index.d.ts"
+ * @import { ErrorHandler, ErrorObject, InstanceOutput } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
@@ -18,116 +17,89 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
       continue;
     }
 
+    const propertyLocations = Pact.pipe(
+      Instance.values(instance),
+      Pact.map(Instance.uri),
+      Pact.collectArray
+    );
+
+    const discriminators = propertyLocations.filter((propertyLocation) => {
+      return oneOf.some((alternative) => isPassingProperty(alternative[propertyLocation]));
+    });
+
+    const alternatives = [];
     const instanceLocation = Instance.uri(instance);
-
     let matchCount = 0;
-    /** @type ErrorObject[][] */
-    const failingAlternatives = [];
 
     for (const alternative of oneOf) {
-      const alternativeErrors = await getErrors(alternative, instance, localization);
-      if (alternativeErrors.length) {
-        failingAlternatives.push(alternativeErrors);
-      } else {
-        matchCount++;
-      }
-    }
-
-    if (matchCount > 1) {
-      /** @type ErrorObject */
-      const error = {
-        message: localization.getOneOfErrorMessage(matchCount),
-        instanceLocation,
-        schemaLocations: [schemaLocation]
-      };
-      if (failingAlternatives.length) {
-        error.alternatives = failingAlternatives;
-      }
-      errors.push(error);
-      continue;
-    }
-
-    let filtered = oneOf;
-
-    const instanceProps = Pact.pipe(
-      Instance.keys(instance),
-      Pact.map((keyNode) => JsonPointer.append(/** @type {string} */ (Instance.value(keyNode)), instanceLocation)),
-      Pact.collectSet
-    );
-
-    const discriminators = Pact.pipe(
-      instanceProps,
-      Pact.filter((propLocation) => Pact.some((alternative) => propertyPasses(alternative[propLocation]), oneOf)),
-      Pact.collectSet
-    );
-
-    filtered = [];
-    for (const alternative of oneOf) {
+      // Filter alternatives whose declared type doesn't match the instance type
       const typeResults = alternative[instanceLocation]?.["https://json-schema.org/keyword/type"];
       if (typeResults && !Object.values(typeResults).every((isValid) => isValid)) {
         continue;
       }
 
       if (Instance.typeOf(instance) === "object") {
-        const declaredProps = Pact.pipe(
-          Object.keys(alternative),
-          Pact.filter((loc) => instanceProps.has(loc)),
-          Pact.collectSet
-        );
-
-        if (!declaredProps.size) {
+        // Filter alternative if it has no declared properties in common with the instance
+        if (!propertyLocations.some((propertyLocation) => propertyLocation in alternative)) {
           continue;
         }
 
-        if (Pact.some((propLocation) => !propertyPasses(alternative[propLocation]), discriminators)) {
+        // Filter alternative if it has failing properties that are declared and passing in another alternative
+        if (discriminators.some((propertyLocation) => !isPassingProperty(alternative[propertyLocation]))) {
           continue;
         }
       }
 
-      filtered.push(alternative);
+      // The alternative passed all the filters
+      const alternativeErrors = await getErrors(alternative, instance, localization);
+      if (alternativeErrors.length) {
+        alternatives.push(alternativeErrors);
+      } else {
+        matchCount++;
+      }
     }
 
-    if (filtered.length === 0) {
-      filtered = oneOf;
-    }
-
-    /** @type ErrorObject[][] */
-    const alternatives = [];
-
-    if (alternatives.length === 0) {
-      for (const alternative of filtered) {
+    if (matchCount === 0 && alternatives.length === 0) {
+      for (const alternative of oneOf) {
         const alternativeErrors = await getErrors(alternative, instance, localization);
-        if (alternativeErrors.length) {
-          alternatives.push(alternativeErrors);
-        }
+        alternatives.push(alternativeErrors);
       }
     }
 
-    if (alternatives.length === 1) {
+    if (alternatives.length === 1 && matchCount === 0) {
       errors.push(...alternatives[0]);
     } else {
       /** @type ErrorObject */
-      const error = {
-        message: localization.getOneOfErrorMessage(0),
-        instanceLocation,
+      const alternativeErrors = {
+        message: localization.getOneOfErrorMessage(matchCount),
+        instanceLocation: Instance.uri(instance),
         schemaLocations: [schemaLocation]
       };
       if (alternatives.length) {
-        error.alternatives = alternatives;
+        alternativeErrors.alternatives = alternatives;
       }
-      errors.push(error);
+      errors.push(alternativeErrors);
     }
   }
 
   return errors;
 };
 
-/** @type (propOutput: NormalizedOutput[string] | undefined) => boolean */
-const propertyPasses = (propOutput) => {
-  if (!propOutput) {
+/** @type (alternative: InstanceOutput | undefined) => boolean */
+const isPassingProperty = (propertyOutput) => {
+  if (!propertyOutput) {
     return false;
   }
-  return Object.values(propOutput).every((keywordResults) => Object.values(keywordResults).every((v) => v === true));
+
+  for (const keywordUri in propertyOutput) {
+    for (const schemaLocation in propertyOutput[keywordUri]) {
+      if (propertyOutput[keywordUri][schemaLocation] !== true) {
+        return false;
+      }
+    }
+  }
+
+  return true;
 };
 
 export default oneOfErrorHandler;

--- a/src/error-handlers/oneOf.js
+++ b/src/error-handlers/oneOf.js
@@ -49,48 +49,55 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
 
     let filtered = oneOf;
 
-    if (Instance.typeOf(instance) === "object") {
-      const instanceProps = Pact.collectSet(
-        Pact.map(
-          (keyNode) => /** @type {string} */ (Instance.value(keyNode)),
-          Instance.keys(instance)
-        )
-      );
-      const prefix = `${instanceLocation}/`;
+    const isObject = Instance.typeOf(instance) === "object";
+    const instanceProps = isObject
+      ? Pact.collectSet(Pact.map((keyNode) => /** @type {string} */ (Instance.value(keyNode)), Instance.keys(instance)))
+      : undefined;
+    const prefix = `${instanceLocation}/`;
 
-      filtered = [];
-      for (const alternative of oneOf) {
-        const typeResults = alternative[instanceLocation]?.["https://json-schema.org/keyword/type"];
-        if (typeResults && !Object.values(typeResults).every((isValid) => isValid)) {
-          continue;
-        }
-
-        const declaredProps = Object.keys(alternative)
-          .filter((loc) => loc.startsWith(prefix))
-          .map((loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1)))));
-
-        if (declaredProps.length > 0 && !declaredProps.some((prop) => instanceProps.has(prop))) {
-          continue;
-        }
-
-        if (!Pact.some((prop) => propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), instanceProps)) {
-          continue;
-        }
-
-        filtered.push(alternative);
+    filtered = [];
+    for (const alternative of oneOf) {
+      const typeResults = alternative[instanceLocation]?.["https://json-schema.org/keyword/type"];
+      if (typeResults && !Object.values(typeResults).every((isValid) => isValid)) {
+        continue;
       }
-    } else {
-      filtered = [];
-      for (const alternative of oneOf) {
-        const typeResults = alternative[instanceLocation]["https://json-schema.org/keyword/type"];
-        if (!typeResults || Object.values(typeResults).every((isValid) => isValid)) {
-          filtered.push(alternative);
+
+      if (isObject) {
+        const declaredProps = Pact.map(
+          (loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1)))),
+          Pact.filter((loc) => loc.startsWith(prefix), Object.keys(alternative))
+        );
+
+        let hasDeclaredProps = false;
+        const hasMatchingProp = Pact.some((prop) => {
+          hasDeclaredProps = true;
+          return /** @type {Set<string>} */ (instanceProps).has(prop);
+        }, declaredProps);
+        if (hasDeclaredProps && !hasMatchingProp) {
+          continue;
         }
       }
+
+      filtered.push(alternative);
     }
 
     if (filtered.length === 0) {
       filtered = oneOf;
+    }
+
+    if (isObject) {
+      const discriminators = Pact.collectSet(
+        Pact.filter(
+          (prop) => Pact.some((alternative) => propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), filtered),
+          /** @type {Set<string>} */ (instanceProps)
+        )
+      );
+
+      const afterRule2 = Pact.collectArray(Pact.filter((alternative) => !Pact.some((prop) => !propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), discriminators), filtered));
+
+      if (afterRule2.length > 0) {
+        filtered = afterRule2;
+      }
     }
 
     const alternatives = [];
@@ -122,7 +129,7 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
 
 /** @type (propOutput: NormalizedOutput[string] | undefined) => boolean */
 const propertyPasses = (propOutput) => {
-  if (!propOutput || Object.keys(propOutput).length === 0) {
+  if (!propOutput) {
     return false;
   }
   return Object.values(propOutput).every((keywordResults) => Object.values(keywordResults).every((v) => v === true));

--- a/src/error-handlers/oneOf.js
+++ b/src/error-handlers/oneOf.js
@@ -51,7 +51,7 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
 
     const isObject = Instance.typeOf(instance) === "object";
     const instanceProps = isObject
-      ? Pact.collectSet(Pact.map((keyNode) => /** @type {string} */ (Instance.value(keyNode)), Instance.keys(instance)))
+      ? Pact.collectSet(Pact.pipe(Instance.keys(instance), Pact.map((keyNode) => /** @type {string} */ (Instance.value(keyNode)))))
       : undefined;
     const prefix = `${instanceLocation}/`;
 
@@ -63,17 +63,13 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
       }
 
       if (isObject) {
-        const declaredProps = Pact.map(
-          (loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1)))),
-          Pact.filter((loc) => loc.startsWith(prefix), Object.keys(alternative))
-        );
+        const declaredProps = Pact.collectSet(Pact.pipe(
+          Object.keys(alternative),
+          Pact.filter((loc) => loc.startsWith(prefix)),
+          Pact.map((loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1)))))
+        ));
 
-        let hasDeclaredProps = false;
-        const hasMatchingProp = Pact.some((prop) => {
-          hasDeclaredProps = true;
-          return /** @type {Set<string>} */ (instanceProps).has(prop);
-        }, declaredProps);
-        if (hasDeclaredProps && !hasMatchingProp) {
+        if (declaredProps.size > 0 && !Pact.some((prop) => declaredProps.has(prop), /** @type {Set<string>} */ (instanceProps))) {
           continue;
         }
       }
@@ -85,26 +81,37 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
       filtered = oneOf;
     }
 
+    /** @type ErrorObject[][] */
+    const alternatives = [];
+
     if (isObject) {
       const discriminators = Pact.collectSet(
-        Pact.filter(
-          (prop) => Pact.some((alternative) => propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), filtered),
-          /** @type {Set<string>} */ (instanceProps)
-        )
+        /** @type {Iterable<string>} */ (Pact.pipe(
+          filtered,
+          Pact.map((alternative) => Pact.pipe(
+            /** @type {Set<string>} */ (instanceProps),
+            Pact.filter((prop) => propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]))
+          )),
+          Pact.flatten
+        ))
       );
 
-      const afterRule2 = Pact.collectArray(Pact.filter((alternative) => !Pact.some((prop) => !propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), discriminators), filtered));
-
-      if (afterRule2.length > 0) {
-        filtered = afterRule2;
+      for (const alternative of filtered) {
+        if (!Pact.some((prop) => !propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), discriminators)) {
+          const alternativeErrors = await getErrors(alternative, instance, localization);
+          if (alternativeErrors.length) {
+            alternatives.push(alternativeErrors);
+          }
+        }
       }
     }
 
-    const alternatives = [];
-    for (const alternative of filtered) {
-      const alternativeErrors = await getErrors(alternative, instance, localization);
-      if (alternativeErrors.length) {
-        alternatives.push(alternativeErrors);
+    if (alternatives.length === 0) {
+      for (const alternative of filtered) {
+        const alternativeErrors = await getErrors(alternative, instance, localization);
+        if (alternativeErrors.length) {
+          alternatives.push(alternativeErrors);
+        }
       }
     }
 
@@ -112,15 +119,15 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
       errors.push(...alternatives[0]);
     } else {
       /** @type ErrorObject */
-      const alternativeErrors = {
+      const error = {
         message: localization.getOneOfErrorMessage(0),
         instanceLocation,
         schemaLocations: [schemaLocation]
       };
       if (alternatives.length) {
-        alternativeErrors.alternatives = alternatives;
+        error.alternatives = alternatives;
       }
-      errors.push(alternativeErrors);
+      errors.push(error);
     }
   }
 

--- a/src/error-handlers/oneOf.js
+++ b/src/error-handlers/oneOf.js
@@ -122,10 +122,10 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
 
 /** @type (propOutput: NormalizedOutput[string] | undefined) => boolean */
 const propertyPasses = (propOutput) => {
-  if (!propOutput || Object.keys(propOutput).length === 0) return false;
-  return Object.values(propOutput).every((keywordResults) =>
-    Object.values(keywordResults).every((v) => v === true)
-  );
+  if (!propOutput || Object.keys(propOutput).length === 0) {
+    return false;
+  }
+  return Object.values(propOutput).every((keywordResults) => Object.values(keywordResults).every((v) => v === true));
 };
 
 export default oneOfErrorHandler;

--- a/src/error-handlers/oneOf.js
+++ b/src/error-handlers/oneOf.js
@@ -49,11 +49,17 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
 
     let filtered = oneOf;
 
-    const isObject = Instance.typeOf(instance) === "object";
-    const instanceProps = isObject
-      ? Pact.collectSet(Pact.pipe(Instance.keys(instance), Pact.map((keyNode) => /** @type {string} */ (Instance.value(keyNode)))))
-      : undefined;
-    const prefix = `${instanceLocation}/`;
+    const instanceProps = Pact.pipe(
+      Instance.keys(instance),
+      Pact.map((keyNode) => JsonPointer.append(/** @type {string} */ (Instance.value(keyNode)), instanceLocation)),
+      Pact.collectSet
+    );
+
+    const discriminators = Pact.pipe(
+      instanceProps,
+      Pact.filter((propLocation) => Pact.some((alternative) => propertyPasses(alternative[propLocation]), oneOf)),
+      Pact.collectSet
+    );
 
     filtered = [];
     for (const alternative of oneOf) {
@@ -62,14 +68,18 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
         continue;
       }
 
-      if (isObject) {
-        const declaredProps = Pact.collectSet(Pact.pipe(
+      if (Instance.typeOf(instance) === "object") {
+        const declaredProps = Pact.pipe(
           Object.keys(alternative),
-          Pact.filter((loc) => loc.startsWith(prefix)),
-          Pact.map((loc) => /** @type {string} */ (Pact.head(JsonPointer.pointerSegments(loc.slice(prefix.length - 1)))))
-        ));
+          Pact.filter((loc) => instanceProps.has(loc)),
+          Pact.collectSet
+        );
 
-        if (declaredProps.size > 0 && !Pact.some((prop) => declaredProps.has(prop), /** @type {Set<string>} */ (instanceProps))) {
+        if (!declaredProps.size) {
+          continue;
+        }
+
+        if (Pact.some((propLocation) => !propertyPasses(alternative[propLocation]), discriminators)) {
           continue;
         }
       }
@@ -83,28 +93,6 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
 
     /** @type ErrorObject[][] */
     const alternatives = [];
-
-    if (isObject) {
-      const discriminators = Pact.collectSet(
-        /** @type {Iterable<string>} */ (Pact.pipe(
-          filtered,
-          Pact.map((alternative) => Pact.pipe(
-            /** @type {Set<string>} */ (instanceProps),
-            Pact.filter((prop) => propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]))
-          )),
-          Pact.flatten
-        ))
-      );
-
-      for (const alternative of filtered) {
-        if (!Pact.some((prop) => !propertyPasses(alternative[JsonPointer.append(prop, instanceLocation)]), discriminators)) {
-          const alternativeErrors = await getErrors(alternative, instance, localization);
-          if (alternativeErrors.length) {
-            alternatives.push(alternativeErrors);
-          }
-        }
-      }
-    }
 
     if (alternatives.length === 0) {
       for (const alternative of filtered) {

--- a/src/error-handlers/oneOf.js
+++ b/src/error-handlers/oneOf.js
@@ -2,52 +2,128 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 import { getErrors } from "../json-schema-errors.js";
 
 /**
- * @import { ErrorHandler, ErrorObject } from "../index.d.ts"
+ * @import { ErrorHandler, ErrorObject, NormalizedOutput } from "../index.d.ts"
  */
+
+/** @type (alternative: NormalizedOutput, propLocation: string) => boolean */
+const propertyPasses = (alternative, propLocation) => {
+  const propOutput = alternative[propLocation];
+  if (!propOutput || Object.keys(propOutput).length === 0) return false;
+  return Object.values(propOutput).every((keywordResults) =>
+    Object.values(keywordResults).every((v) => v === true)
+  );
+};
 
 /** @type ErrorHandler */
 const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
   /** @type ErrorObject[] */
   const errors = [];
 
-  for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/oneOf"]) {
-    const oneOf = normalizedErrors["https://json-schema.org/keyword/oneOf"][schemaLocation];
+  for (const schemaLocation in normalizedErrors[
+    "https://json-schema.org/keyword/oneOf"
+  ]) {
+    const oneOf
+      = normalizedErrors["https://json-schema.org/keyword/oneOf"][schemaLocation];
     if (typeof oneOf === "boolean") {
       continue;
     }
 
-    const alternatives = [];
     const instanceLocation = Instance.uri(instance);
+
     let matchCount = 0;
+    /** @type ErrorObject[][] */
+    const failingAlternatives = [];
 
     for (const alternative of oneOf) {
-      const typeErrors = alternative[instanceLocation]?.["https://json-schema.org/keyword/type"];
-      const match = !typeErrors || Object.values(typeErrors).every((isValid) => isValid);
-
-      if (match) {
-        const alternativeErrors = await getErrors(alternative, instance, localization);
-        if (alternativeErrors.length) {
-          alternatives.push(alternativeErrors);
-        } else {
-          matchCount++;
-        }
+      const alternativeErrors = await getErrors(
+        alternative,
+        instance,
+        localization
+      );
+      if (alternativeErrors.length) {
+        failingAlternatives.push(alternativeErrors);
+      } else {
+        matchCount++;
       }
     }
 
-    if (matchCount === 0 && alternatives.length === 0) {
-      for (const alternative of oneOf) {
-        const alternativeErrors = await getErrors(alternative, instance, localization);
+    if (matchCount > 1) {
+      /** @type ErrorObject */
+      const error = {
+        message: localization.getOneOfErrorMessage(matchCount),
+        instanceLocation,
+        schemaLocations: [schemaLocation]
+      };
+      if (failingAlternatives.length) {
+        error.alternatives = failingAlternatives;
+      }
+      errors.push(error);
+      continue;
+    }
+
+    let filtered = oneOf;
+
+    if (Instance.typeOf(instance) === "object") {
+      const instanceProps = new Set(
+        [...Instance.keys(instance)].map(
+          (keyNode) => /** @type {string} */ (Instance.value(keyNode))
+        )
+      );
+      const prefix = `${instanceLocation}/`;
+
+      filtered = filtered.filter((alternative) => {
+        const declaredProps = Object.keys(alternative)
+          .filter((loc) => loc.startsWith(prefix))
+          .map((loc) => loc.slice(prefix.length));
+
+        if (declaredProps.length === 0) return true;
+        return declaredProps.some((prop) => instanceProps.has(prop));
+      });
+
+      filtered = filtered.filter((alternative) =>
+        [...instanceProps].some((prop) =>
+          propertyPasses(alternative, `${instanceLocation}/${prop}`)
+        )
+      );
+
+      if (filtered.length === 0) {
+        filtered = oneOf;
+      }
+    } else {
+      filtered = filtered.filter((alternative) => {
+        const typeResults
+          = alternative[instanceLocation]?.[
+            "https://json-schema.org/keyword/type"
+          ];
+        return (
+          !typeResults || Object.values(typeResults).every((isValid) => isValid)
+        );
+      });
+
+      if (filtered.length === 0) {
+        filtered = oneOf;
+      }
+    }
+
+    const alternatives = [];
+    for (const alternative of filtered) {
+      const alternativeErrors = await getErrors(
+        alternative,
+        instance,
+        localization
+      );
+      if (alternativeErrors.length) {
         alternatives.push(alternativeErrors);
       }
     }
 
-    if (alternatives.length === 1 && matchCount === 0) {
+    if (alternatives.length === 1) {
       errors.push(...alternatives[0]);
     } else {
       /** @type ErrorObject */
       const alternativeErrors = {
-        message: localization.getOneOfErrorMessage(matchCount),
-        instanceLocation: Instance.uri(instance),
+        message: localization.getOneOfErrorMessage(0),
+        instanceLocation,
         schemaLocations: [schemaLocation]
       };
       if (alternatives.length) {

--- a/src/test-suite/tests/anyOf.json
+++ b/src/test-suite/tests/anyOf.json
@@ -20,7 +20,7 @@
               {
                 "messageId": "type-message",
                 "messageParams": {
-                  "expectedTypes": "string"
+                  "expectedTypes": { "or": ["string"] }
                 },
                 "instanceLocation": "#",
                 "schemaLocations": ["#/anyOf/0/type"]
@@ -30,7 +30,7 @@
               {
                 "messageId": "type-message",
                 "messageParams": {
-                  "expectedTypes": "number"
+                  "expectedTypes": { "or": ["number"] }
                 },
                 "instanceLocation": "#",
                 "schemaLocations": ["#/anyOf/1/type"]
@@ -255,6 +255,91 @@
       ]
     },
     {
+      "description": "alternatives with no declared properties matching the instance are filtered out",
+      "schema": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "a": { "type": "string" }
+            },
+            "required": ["a"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "b": { "type": "string" }
+            },
+            "required": ["b"]
+          }
+        ]
+      },
+      "instance": { "a": 42 },
+      "errors": [
+        {
+          "messageId": "type-message",
+          "messageParams": {
+            "expectedTypes": { "or": ["string"] }
+          },
+          "instanceLocation": "#/a",
+          "schemaLocations": ["#/anyOf/0/properties/a/type"]
+        }
+      ]
+    },
+    {
+      "description": "None of the instance properties are declared in any of the alternatives",
+      "schema": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "a": { "type": "string" }
+            },
+            "required": ["a"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "b": { "type": "string" }
+            },
+            "required": ["b"]
+          }
+        ]
+      },
+      "instance": { "c": 42 },
+      "errors": [
+        {
+          "messageId": "anyOf-message",
+          "alternatives": [
+            [
+              {
+                "messageId": "required-message",
+                "messageParams": {
+                  "required": { "and": ["a"] },
+                  "count": 1
+                },
+                "instanceLocation": "#",
+                "schemaLocations": ["#/anyOf/0/required"]
+              }
+            ],
+            [
+              {
+                "messageId": "required-message",
+                "messageParams": {
+                  "required": { "and": ["b"] },
+                  "count": 1
+                },
+                "instanceLocation": "#",
+                "schemaLocations": ["#/anyOf/1/required"]
+              }
+            ]
+          ],
+          "instanceLocation": "#",
+          "schemaLocations": ["#/anyOf"]
+        }
+      ]
+    },
+    {
       "description": "anyOf object alternatives keep only one branch when only one branch has a passing instance property",
       "compatibility": "6",
       "schema": {
@@ -282,7 +367,7 @@
         {
           "messageId": "type-message",
           "messageParams": {
-            "expectedTypes": "number"
+            "expectedTypes": { "or": ["number"] }
           },
           "instanceLocation": "#/b",
           "schemaLocations": ["#/anyOf/1/properties/b/type"]
@@ -326,7 +411,7 @@
               {
                 "messageId": "type-message",
                 "messageParams": {
-                  "expectedTypes": "string"
+                  "expectedTypes": { "or": ["string"] }
                 },
                 "instanceLocation": "#/x",
                 "schemaLocations": ["#/anyOf/0/properties/x/type"]
@@ -430,6 +515,42 @@
           ],
           "instanceLocation": "#",
           "schemaLocations": ["#/anyOf"]
+        }
+      ]
+    },
+    {
+      "description": "Compound discriminators",
+      "schema": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "foo": { "enum": ["a"] },
+              "bar": { "enum": ["b"] },
+              "a": { "type": "string" }
+            },
+            "required": ["foo", "bar"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "foo": { "enum": ["a"] },
+              "bar": { "enum": ["c"] },
+              "b": { "type": "string" }
+            },
+            "required": ["foo", "bar"]
+          }
+        ]
+      },
+      "instance": { "foo": "a", "bar": "c", "b": 42 },
+      "errors": [
+        {
+          "messageId": "type-message",
+          "messageParams": {
+            "expectedTypes": { "or": ["string"] }
+          },
+          "instanceLocation": "#/b",
+          "schemaLocations": ["#/anyOf/1/properties/b/type"]
         }
       ]
     }

--- a/src/test-suite/tests/anyOf.json
+++ b/src/test-suite/tests/anyOf.json
@@ -253,6 +253,152 @@
           "schemaLocations": ["https://example.com/main#/anyOf"]
         }
       ]
+    },
+    {
+      "description": "anyOf object alternatives keep only one branch when only one branch has a passing instance property",
+      "compatibility": "6",
+      "schema": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": { "const": "a" },
+              "a": { "type": "string" }
+            },
+            "required": ["type", "a"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": { "const": "b" },
+              "b": { "type": "number" }
+            },
+            "required": ["type", "b"]
+          }
+        ]
+      },
+      "instance": { "type": "b", "b": "oops" },
+      "errors": [
+        {
+          "messageId": "type-message",
+          "messageParams": {
+            "expectedTypes": "number"
+          },
+          "instanceLocation": "#/b",
+          "schemaLocations": ["#/anyOf/1/properties/b/type"]
+        }
+      ]
+    },
+    {
+      "description": "anyOf object alternatives keep both branches when each branch has at least one passing instance property",
+      "compatibility": "6",
+      "schema": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": { "const": "a" },
+              "x": { "type": "string" }
+            },
+            "required": ["type", "x"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "allOf": [
+                  { "type": "string" },
+                  { "minLength": 2 }
+                ]
+              },
+              "x": { "type": "number" }
+            },
+            "required": ["type", "x"]
+          }
+        ]
+      },
+      "instance": { "type": "a", "x": 42 },
+      "errors": [
+        {
+          "messageId": "anyOf-message",
+          "alternatives": [
+            [
+              {
+                "messageId": "type-message",
+                "messageParams": {
+                  "expectedTypes": "string"
+                },
+                "instanceLocation": "#/x",
+                "schemaLocations": ["#/anyOf/0/properties/x/type"]
+              }
+            ],
+            [
+              {
+                "messageId": "minLength-message",
+                "messageParams": {
+                  "minLength": "2"
+                },
+                "instanceLocation": "#/type",
+                "schemaLocations": ["#/anyOf/1/properties/type/allOf/1/minLength"]
+              }
+            ]
+          ],
+          "instanceLocation": "#",
+          "schemaLocations": ["#/anyOf"]
+        }
+      ]
+    },
+    {
+      "description": "anyOf object alternatives fallback to all when no instance property passes in any branch",
+      "compatibility": "6",
+      "schema": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": { "const": "a" }
+            },
+            "required": ["kind"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": { "const": "b" }
+            },
+            "required": ["kind"]
+          }
+        ]
+      },
+      "instance": { "kind": "c" },
+      "errors": [
+        {
+          "messageId": "anyOf-message",
+          "alternatives": [
+            [
+              {
+                "messageId": "const-message",
+                "messageParams": {
+                  "expected": "\"a\""
+                },
+                "instanceLocation": "#/kind",
+                "schemaLocations": ["#/anyOf/0/properties/kind/const"]
+              }
+            ],
+            [
+              {
+                "messageId": "const-message",
+                "messageParams": {
+                  "expected": "\"b\""
+                },
+                "instanceLocation": "#/kind",
+                "schemaLocations": ["#/anyOf/1/properties/kind/const"]
+              }
+            ]
+          ],
+          "instanceLocation": "#",
+          "schemaLocations": ["#/anyOf"]
+        }
+      ]
     }
   ]
 }

--- a/src/test-suite/tests/anyOf.json
+++ b/src/test-suite/tests/anyOf.json
@@ -349,6 +349,39 @@
       ]
     },
     {
+      "description": "anyOf object alternatives filters to matching branch by declared property intersection",
+      "compatibility": "6",
+      "schema": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "a": { "type": "string" }
+            },
+            "required": ["a"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "b": { "type": "string" }
+            },
+            "required": ["b"]
+          }
+        ]
+      },
+      "instance": { "a": 42 },
+      "errors": [
+        {
+          "messageId": "type-message",
+          "messageParams": {
+            "expectedTypes": "string"
+          },
+          "instanceLocation": "#/a",
+          "schemaLocations": ["#/anyOf/0/properties/a/type"]
+        }
+      ]
+    },
+    {
       "description": "anyOf object alternatives fallback to all when no instance property passes in any branch",
       "compatibility": "6",
       "schema": {

--- a/src/test-suite/tests/oneOf.json
+++ b/src/test-suite/tests/oneOf.json
@@ -358,6 +358,39 @@
       ]
     },
     {
+      "description": "oneOf object alternatives filters to matching branch by declared property intersection",
+      "compatibility": "6",
+      "schema": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "a": { "type": "string" }
+            },
+            "required": ["a"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "b": { "type": "string" }
+            },
+            "required": ["b"]
+          }
+        ]
+      },
+      "instance": { "a": 42 },
+      "errors": [
+        {
+          "messageId": "type-message",
+          "messageParams": {
+            "expectedTypes": "string"
+          },
+          "instanceLocation": "#/a",
+          "schemaLocations": ["#/oneOf/0/properties/a/type"]
+        }
+      ]
+    },
+    {
       "description": "oneOf object alternatives fallback to all when no instance property passes in any branch",
       "compatibility": "6",
       "schema": {

--- a/src/test-suite/tests/oneOf.json
+++ b/src/test-suite/tests/oneOf.json
@@ -15,7 +15,9 @@
       "errors": [
         {
           "messageId": "oneOf-message",
-          "messageParams": { "matchCount": 0 },
+          "messageParams": {
+            "matchCount": 0
+          },
           "alternatives": [
             [
               {
@@ -323,6 +325,94 @@
       ]
     },
     {
+      "description": "alternatives with no declared properties matching the instance are filtered out",
+      "schema": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "a": { "type": "string" }
+            },
+            "required": ["a"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "b": { "type": "string" }
+            },
+            "required": ["b"]
+          }
+        ]
+      },
+      "instance": { "a": 42 },
+      "errors": [
+        {
+          "messageId": "type-message",
+          "messageParams": {
+            "expectedTypes": { "or": ["string"] }
+          },
+          "instanceLocation": "#/a",
+          "schemaLocations": ["#/oneOf/0/properties/a/type"]
+        }
+      ]
+    },
+    {
+      "description": "None of the instance properties are declared in any of the alternatives",
+      "schema": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "a": { "type": "string" }
+            },
+            "required": ["a"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "b": { "type": "string" }
+            },
+            "required": ["b"]
+          }
+        ]
+      },
+      "instance": { "c": 42 },
+      "errors": [
+        {
+          "messageId": "oneOf-message",
+          "messageParams": {
+            "matchCount": 0
+          },
+          "alternatives": [
+            [
+              {
+                "messageId": "required-message",
+                "messageParams": {
+                  "required": { "and": ["a"] },
+                  "count": 1
+                },
+                "instanceLocation": "#",
+                "schemaLocations": ["#/oneOf/0/required"]
+              }
+            ],
+            [
+              {
+                "messageId": "required-message",
+                "messageParams": {
+                  "required": { "and": ["b"] },
+                  "count": 1
+                },
+                "instanceLocation": "#",
+                "schemaLocations": ["#/oneOf/1/required"]
+              }
+            ]
+          ],
+          "instanceLocation": "#",
+          "schemaLocations": ["#/oneOf"]
+        }
+      ]
+    },
+    {
       "description": "oneOf object alternatives keep only one branch when only one branch has a passing instance property",
       "compatibility": "6",
       "schema": {
@@ -350,7 +440,7 @@
         {
           "messageId": "type-message",
           "messageParams": {
-            "expectedTypes": "number"
+            "expectedTypes": { "or": ["number"] }
           },
           "instanceLocation": "#/b",
           "schemaLocations": ["#/oneOf/1/properties/b/type"]
@@ -383,7 +473,7 @@
         {
           "messageId": "type-message",
           "messageParams": {
-            "expectedTypes": "string"
+            "expectedTypes": { "or": ["string"] }
           },
           "instanceLocation": "#/a",
           "schemaLocations": ["#/oneOf/0/properties/a/type"]
@@ -485,7 +575,7 @@
               {
                 "messageId": "type-message",
                 "messageParams": {
-                  "expectedTypes": "string"
+                  "expectedTypes": { "or": ["string"] }
                 },
                 "instanceLocation": "#/x",
                 "schemaLocations": ["#/oneOf/0/properties/x/type"]
@@ -504,6 +594,42 @@
           ],
           "instanceLocation": "#",
           "schemaLocations": ["#/oneOf"]
+        }
+      ]
+    },
+    {
+      "description": "Compound discriminators",
+      "schema": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "foo": { "enum": ["a"] },
+              "bar": { "enum": ["b"] },
+              "a": { "type": "string" }
+            },
+            "required": ["foo", "bar"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "foo": { "enum": ["a"] },
+              "bar": { "enum": ["c"] },
+              "b": { "type": "string" }
+            },
+            "required": ["foo", "bar"]
+          }
+        ]
+      },
+      "instance": { "foo": "a", "bar": "c", "b": 42 },
+      "errors": [
+        {
+          "messageId": "type-message",
+          "messageParams": {
+            "expectedTypes": { "or": ["string"] }
+          },
+          "instanceLocation": "#/b",
+          "schemaLocations": ["#/oneOf/1/properties/b/type"]
         }
       ]
     }

--- a/src/test-suite/tests/oneOf.json
+++ b/src/test-suite/tests/oneOf.json
@@ -321,6 +321,158 @@
           "schemaLocations": ["https://example.com/main#/oneOf"]
         }
       ]
+    },
+    {
+      "description": "oneOf object alternatives keep only one branch when only one branch has a passing instance property",
+      "compatibility": "6",
+      "schema": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": { "const": "a" },
+              "a": { "type": "string" }
+            },
+            "required": ["type", "a"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": { "const": "b" },
+              "b": { "type": "number" }
+            },
+            "required": ["type", "b"]
+          }
+        ]
+      },
+      "instance": { "type": "b", "b": "oops" },
+      "errors": [
+        {
+          "messageId": "type-message",
+          "messageParams": {
+            "expectedTypes": "number"
+          },
+          "instanceLocation": "#/b",
+          "schemaLocations": ["#/oneOf/1/properties/b/type"]
+        }
+      ]
+    },
+    {
+      "description": "oneOf object alternatives fallback to all when no instance property passes in any branch",
+      "compatibility": "6",
+      "schema": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": { "const": "a" }
+            },
+            "required": ["kind"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": { "const": "b" }
+            },
+            "required": ["kind"]
+          }
+        ]
+      },
+      "instance": { "kind": "c" },
+      "errors": [
+        {
+          "messageId": "oneOf-message",
+          "messageParams": {
+            "matchCount": 0
+          },
+          "alternatives": [
+            [
+              {
+                "messageId": "const-message",
+                "messageParams": {
+                  "expected": "\"a\""
+                },
+                "instanceLocation": "#/kind",
+                "schemaLocations": ["#/oneOf/0/properties/kind/const"]
+              }
+            ],
+            [
+              {
+                "messageId": "const-message",
+                "messageParams": {
+                  "expected": "\"b\""
+                },
+                "instanceLocation": "#/kind",
+                "schemaLocations": ["#/oneOf/1/properties/kind/const"]
+              }
+            ]
+          ],
+          "instanceLocation": "#",
+          "schemaLocations": ["#/oneOf"]
+        }
+      ]
+    },
+    {
+      "description": "oneOf object alternatives keep both branches when each branch has at least one passing instance property",
+      "compatibility": "6",
+      "schema": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": { "const": "a" },
+              "x": { "type": "string" }
+            },
+            "required": ["type", "x"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "allOf": [
+                  { "type": "string" },
+                  { "minLength": 2 }
+                ]
+              },
+              "x": { "type": "number" }
+            },
+            "required": ["type", "x"]
+          }
+        ]
+      },
+      "instance": { "type": "a", "x": 42 },
+      "errors": [
+        {
+          "messageId": "oneOf-message",
+          "messageParams": {
+            "matchCount": 0
+          },
+          "alternatives": [
+            [
+              {
+                "messageId": "type-message",
+                "messageParams": {
+                  "expectedTypes": "string"
+                },
+                "instanceLocation": "#/x",
+                "schemaLocations": ["#/oneOf/0/properties/x/type"]
+              }
+            ],
+            [
+              {
+                "messageId": "minLength-message",
+                "messageParams": {
+                  "minLength": "2"
+                },
+                "instanceLocation": "#/type",
+                "schemaLocations": ["#/oneOf/1/properties/type/allOf/1/minLength"]
+              }
+            ]
+          ],
+          "instanceLocation": "#",
+          "schemaLocations": ["#/oneOf"]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
The anyof and oneof error handlers now filter alternatives based on the instance's properties. For object instances, an alternative is excluded from the error report if none of its declared properties exist on the instance (Rule 1), or if none of the instance's properties pass validation in that alternative (Rule 2). For non-object instances, the original type-keyword filtering is done.

fixes #175 