### PR TITLE
Move getErrors to public API

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -73,3 +73,5 @@ export const addErrorHandler: (handler: ErrorHandler) => void;
 export type ErrorHandler = (normalizedErrors: InstanceOutput, instance: JsonNode, localization: Localization) => Promise<ErrorObject[]>;
 
 export const evaluateSchema: (schemaLocation: string, instance: JsonNode, context: EvaluationContext) => NormalizedOutput;
+
+export const getErrors: (normalizedErrors: NormalizedOutput, rootInstance: JsonNode, language: Localization) => Promise<ErrorObject[]>;

--- a/src/index.js
+++ b/src/index.js
@@ -171,6 +171,7 @@ addErrorHandler(unknownErrorHandler);
 export {
   addErrorHandler,
   evaluateSchema,
+  getErrors,
   jsonSchemaErrors,
   setNormalizationHandler
 } from "./json-schema-errors.js";

--- a/src/json-schema-errors.js
+++ b/src/json-schema-errors.js
@@ -181,7 +181,7 @@ export const addErrorHandler = (errorHandler) => {
   errorHandlers.push(errorHandler);
 };
 
-/** @type (normalizedErrors: API.NormalizedOutput, rootInstance: JsonNode, language: Localization) => Promise<API.ErrorObject[]> */
+/** @type API.getErrors */
 export const getErrors = async (normalizedErrors, rootInstance, localization) => {
   /** @type API.ErrorObject[] */
   const errors = [];


### PR DESCRIPTION
The `getErrors` function is sometimes needed in error handlers. I'm moving it to the public API so it can be used by users in custom error handlers.