### PR TITLE
Use star-pointer syntax for property names

### DIFF
--- a/src/json-schema-errors.js
+++ b/src/json-schema-errors.js
@@ -58,7 +58,8 @@ const constructErrorIndex = async (outputUnit, schema, errorIndex = {}) => {
 
     const absoluteKeywordLocation = errorOutputUnit.absoluteKeywordLocation
       ?? await toAbsoluteKeywordLocation(schema, /** @type string */ (errorOutputUnit.keywordLocation));
-    const instanceLocation = normalizeInstanceLocation(/** @type string */ (errorOutputUnit.instanceLocation));
+    const instanceLocation = /** @type string */ (errorOutputUnit.instanceLocation)
+      .replace(/^#?\*?/, "#");
 
     errorIndex[absoluteKeywordLocation] ??= {};
     errorIndex[absoluteKeywordLocation][instanceLocation] = true;
@@ -83,12 +84,6 @@ async function toAbsoluteKeywordLocation(schema, keywordLocation) {
   }
 
   return `${schema.document.baseUri}#${schema.cursor}`;
-}
-
-/** @type {(location: string) => string} */
-function normalizeInstanceLocation(location) {
-  const instanceLocation = location.startsWith("/") || location === "" ? `#${location}` : location;
-  return instanceLocation.replace(/(#|^)\*\//, "$1/");
 }
 
 /** @type API.evaluateSchema */
@@ -134,7 +129,7 @@ export const evaluateSchema = (schemaLocation, instance, context) => {
       }
 
       const keywordOutput = keyword.evaluate(keywordValue, instance, keywordContext);
-      const isKeywordValid = !context.errorIndex[keywordLocation]?.[instanceLocation];
+      const isKeywordValid = !context.errorIndex[keywordLocation]?.[instanceLocation.replace(/^#\*/, "#")];
       if (!isKeywordValid) {
         valid = false;
       }

--- a/src/normalization-handlers/propertyNames.js
+++ b/src/normalization-handlers/propertyNames.js
@@ -16,7 +16,6 @@ const propertyNamesNormalizationHandler = {
     }
 
     for (const propertyName of Instance.keys(instance)) {
-      propertyName.pointer = propertyName.pointer.replace(/^\*/, "");
       outputs.push(evaluateSchema(propertyNames, propertyName, context));
     }
 

--- a/src/test-suite/tests/propertyNames.json
+++ b/src/test-suite/tests/propertyNames.json
@@ -16,7 +16,7 @@
           "messageParams": {
             "minLength": "5"
           },
-          "instanceLocation": "#/foo",
+          "instanceLocation": "#*/foo",
           "schemaLocations": ["#/propertyNames/minLength"]
         }
       ]
@@ -34,7 +34,7 @@
           "messageParams": {
             "minLength": "5"
           },
-          "instanceLocation": "#/foo",
+          "instanceLocation": "#*/foo",
           "schemaLocations": ["#/propertyNames/minLength"]
         }
       ]


### PR DESCRIPTION
Reporting for the `propertyNames` keyword has a known problem. We refer to locations using JSON Pointers, but JSON Pointers don't have the ability to point to a property name making it impossible to precisely locate them. In `@hyperjump/json-schema`, I invented a notation to indicate that a pointer pointed to the name of a property an not it's value. It just adds a `*` as a prefix to a normal pointer.

@animeshsahoo1 pointed out that we'll need the capability to point to a property name to properly highlight errors on property names. So, I'm changing this package to use the star-pointer notation as well. We still can't rely on star-pointers being present in the output format that we take in because this should work for any implementation that uses the standard output format and the star-pointer notation isn't standard. But, we can return the start-pointer notation once it's normalized.