### PR TITLE
Making getErrors synchronous

### DIFF
--- a/src/error-handlers/anyOf.js
+++ b/src/error-handlers/anyOf.js
@@ -7,7 +7,7 @@ import { getErrors } from "../json-schema-errors.js";
  */
 
 /** @type ErrorHandler */
-const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
+const anyOfErrorHandler = (normalizedErrors, instance, localization, resolver) => {
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -51,13 +51,13 @@ const anyOfErrorHandler = async (normalizedErrors, instance, localization) => {
       }
 
       // The alternative passed all the filters
-      alternatives.push(await getErrors(alternative, instance, localization));
+      alternatives.push(getErrors(alternative, instance, localization, resolver));
     }
 
     // If all alternatives were filtered out, default to returning all of them
     if (alternatives.length === 0) {
       for (const alternative of anyOf) {
-        alternatives.push(await getErrors(alternative, instance, localization));
+        alternatives.push(getErrors(alternative, instance, localization, resolver));
       }
     }
 

--- a/src/error-handlers/anyOf.js
+++ b/src/error-handlers/anyOf.js
@@ -7,7 +7,7 @@ import { getErrors } from "../json-schema-errors.js";
  */
 
 /** @type ErrorHandler */
-const anyOfErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const anyOfErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -51,13 +51,13 @@ const anyOfErrorHandler = (normalizedErrors, instance, localization, resolver) =
       }
 
       // The alternative passed all the filters
-      alternatives.push(getErrors(alternative, instance, localization, resolver));
+      alternatives.push(getErrors(alternative, instance, localization, ast));
     }
 
     // If all alternatives were filtered out, default to returning all of them
     if (alternatives.length === 0) {
       for (const alternative of anyOf) {
-        alternatives.push(getErrors(alternative, instance, localization, resolver));
+        alternatives.push(getErrors(alternative, instance, localization, ast));
       }
     }
 

--- a/src/error-handlers/boolean-schema.js
+++ b/src/error-handlers/boolean-schema.js
@@ -5,7 +5,7 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const booleanSchemaErrorHandler = async (normalizedErrors, instance, localization) => {
+const booleanSchemaErrorHandler = (normalizedErrors, instance, localization) => {
   /** @type ErrorObject[] */
   const errors = [];
 

--- a/src/error-handlers/contains.js
+++ b/src/error-handlers/contains.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const containsErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getSiblingKeywordValue) {
-    throw new Error("Missing resolver.getSiblingKeywordValue in error handler context");
-  }
-
   /** @type ErrorObject[] */
   const errors = [];
 

--- a/src/error-handlers/contains.js
+++ b/src/error-handlers/contains.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -7,7 +5,15 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const containsErrorHandler = async (normalizedErrors, instance, localization) => {
+const containsErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  /** @type {{
+   *   getSiblingKeywordValue?: (schemaLocation: string, siblingKeywordUri: string) =>
+   *     { keywordLocation: string; keywordValue: unknown } | undefined
+   * } | undefined} */
+  if (!resolver?.getSiblingKeywordValue) {
+    throw new Error("Missing resolver.getSiblingKeywordValue in error handler context");
+  }
+
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -27,24 +33,16 @@ const containsErrorHandler = async (normalizedErrors, instance, localization) =>
 
       /** @type ContainsRange */
       const range = {};
-      const parentLocation = pointerPop(schemaLocation);
-
-      for (const minContainsLocation in normalizedErrors["https://json-schema.org/keyword/minContains"]) {
-        if (pointerPop(minContainsLocation) === parentLocation) {
-          const minContainsNode = await getSchema(minContainsLocation);
-          range.minContains = /** @type number */ (Schema.value(minContainsNode));
-          schemaLocations.push(minContainsLocation);
-          break;
-        }
+      const minContains = resolver.getSiblingKeywordValue(schemaLocation, "https://json-schema.org/keyword/minContains");
+      if (minContains) {
+        range.minContains = /** @type number */ (minContains.keywordValue);
+        schemaLocations.push(minContains.keywordLocation);
       }
 
-      for (const maxContainsLocation in normalizedErrors["https://json-schema.org/keyword/maxContains"]) {
-        if (pointerPop(maxContainsLocation) === parentLocation) {
-          const maxContainsNode = await getSchema(maxContainsLocation);
-          range.maxContains = /** @type number */ (Schema.value(maxContainsNode));
-          schemaLocations.push(maxContainsLocation);
-          break;
-        }
+      const maxContains = resolver.getSiblingKeywordValue(schemaLocation, "https://json-schema.org/keyword/maxContains");
+      if (maxContains) {
+        range.maxContains = /** @type number */ (maxContains.keywordValue);
+        schemaLocations.push(maxContains.keywordLocation);
       }
 
       errors.push({
@@ -57,8 +55,5 @@ const containsErrorHandler = async (normalizedErrors, instance, localization) =>
 
   return errors;
 };
-
-/** @type (pointer: string) => string */
-const pointerPop = (pointer) => pointer.replace(/\/[^/]+$/, "");
 
 export default containsErrorHandler;

--- a/src/error-handlers/contains.js
+++ b/src/error-handlers/contains.js
@@ -1,5 +1,5 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
-import { getSiblingKeywordValue } from "../json-schema-errors.js";
+import { getCompiledKeywordValue, getSiblingKeywordLocation } from "../json-schema-errors.js";
 
 /**
  * @import { ContainsRange, ErrorHandler, ErrorObject } from "../index.d.ts"
@@ -24,20 +24,17 @@ const containsErrorHandler = (normalizedErrors, instance, localization, ast) => 
       /** @type string[] */
       const schemaLocations = [schemaLocation];
 
-      const parentLocation = schemaLocation.replace(/\/[^/]+$/, "");
-      const parentNode = ast[parentLocation];
-      const containsNode = Array.isArray(parentNode) ? parentNode.find(([, keywordLocation]) => keywordLocation === schemaLocation) : undefined;
-      const containsRange = /** @type {ContainsRange} */ (containsNode?.[2] ?? {});
+      const containsRange = /** @type {ContainsRange} */ (getCompiledKeywordValue(ast, schemaLocation));
 
       /** @type ContainsRange */
       const range = {};
-      const minContains = getSiblingKeywordValue(ast, schemaLocation, "https://json-schema.org/keyword/minContains");
+      const minContains = getSiblingKeywordLocation(ast, schemaLocation, "https://json-schema.org/keyword/minContains");
       if (minContains) {
         range.minContains = containsRange.minContains;
         schemaLocations.push(minContains);
       }
 
-      const maxContains = getSiblingKeywordValue(ast, schemaLocation, "https://json-schema.org/keyword/maxContains");
+      const maxContains = getSiblingKeywordLocation(ast, schemaLocation, "https://json-schema.org/keyword/maxContains");
       if (maxContains) {
         range.maxContains = containsRange.maxContains;
         schemaLocations.push(maxContains);

--- a/src/error-handlers/contains.js
+++ b/src/error-handlers/contains.js
@@ -2,6 +2,7 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 import { getCompiledKeywordValue, getSiblingKeywordLocation } from "../json-schema-errors.js";
 
 /**
+ * @import { ContainsAst } from "../normalization-handlers/contains.js"
  * @import { ContainsRange, ErrorHandler, ErrorObject } from "../index.d.ts"
  */
 
@@ -24,20 +25,22 @@ const containsErrorHandler = (normalizedErrors, instance, localization, ast) => 
       /** @type string[] */
       const schemaLocations = [schemaLocation];
 
-      const containsRange = /** @type {ContainsRange} */ (getCompiledKeywordValue(ast, schemaLocation));
+      const contains = /** @type ContainsAst */ (getCompiledKeywordValue(ast, schemaLocation));
 
       /** @type ContainsRange */
       const range = {};
-      const minContains = getSiblingKeywordLocation(ast, schemaLocation, "https://json-schema.org/keyword/minContains");
-      if (minContains) {
-        range.minContains = containsRange.minContains;
-        schemaLocations.push(minContains);
-      }
+      if (typeof contains !== "string") {
+        if (contains.minContains !== 1) {
+          range.minContains = contains.minContains;
+          const minContainsLocation = getSiblingKeywordLocation(ast, schemaLocation, "https://json-schema.org/keyword/minContains");
+          schemaLocations.push(minContainsLocation);
+        }
 
-      const maxContains = getSiblingKeywordLocation(ast, schemaLocation, "https://json-schema.org/keyword/maxContains");
-      if (maxContains) {
-        range.maxContains = containsRange.maxContains;
-        schemaLocations.push(maxContains);
+        if (contains.maxContains !== Number.MAX_SAFE_INTEGER) {
+          range.maxContains = contains.maxContains;
+          const maxContainsLocation = getSiblingKeywordLocation(ast, schemaLocation, "https://json-schema.org/keyword/maxContains");
+          schemaLocations.push(maxContainsLocation);
+        }
       }
 
       errors.push({

--- a/src/error-handlers/contains.js
+++ b/src/error-handlers/contains.js
@@ -1,11 +1,12 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getSiblingKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ContainsRange, ErrorHandler, ErrorObject } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
-const containsErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const containsErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -23,18 +24,23 @@ const containsErrorHandler = (normalizedErrors, instance, localization, resolver
       /** @type string[] */
       const schemaLocations = [schemaLocation];
 
+      const parentLocation = schemaLocation.replace(/\/[^/]+$/, "");
+      const parentNode = ast[parentLocation];
+      const containsNode = Array.isArray(parentNode) ? parentNode.find(([, keywordLocation]) => keywordLocation === schemaLocation) : undefined;
+      const containsRange = /** @type {ContainsRange} */ (containsNode?.[2] ?? {});
+
       /** @type ContainsRange */
       const range = {};
-      const minContains = resolver.getSiblingKeywordValue(schemaLocation, "https://json-schema.org/keyword/minContains");
+      const minContains = getSiblingKeywordValue(ast, schemaLocation, "https://json-schema.org/keyword/minContains");
       if (minContains) {
-        range.minContains = /** @type number */ (minContains.keywordValue);
-        schemaLocations.push(minContains.keywordLocation);
+        range.minContains = containsRange.minContains;
+        schemaLocations.push(minContains);
       }
 
-      const maxContains = resolver.getSiblingKeywordValue(schemaLocation, "https://json-schema.org/keyword/maxContains");
+      const maxContains = getSiblingKeywordValue(ast, schemaLocation, "https://json-schema.org/keyword/maxContains");
       if (maxContains) {
-        range.maxContains = /** @type number */ (maxContains.keywordValue);
-        schemaLocations.push(maxContains.keywordLocation);
+        range.maxContains = containsRange.maxContains;
+        schemaLocations.push(maxContains);
       }
 
       errors.push({

--- a/src/error-handlers/contains.js
+++ b/src/error-handlers/contains.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const containsErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  /** @type {{
-   *   getSiblingKeywordValue?: (schemaLocation: string, siblingKeywordUri: string) =>
-   *     { keywordLocation: string; keywordValue: unknown } | undefined
-   * } | undefined} */
   if (!resolver?.getSiblingKeywordValue) {
     throw new Error("Missing resolver.getSiblingKeywordValue in error handler context");
   }

--- a/src/error-handlers/draft-04/dependencies.js
+++ b/src/error-handlers/draft-04/dependencies.js
@@ -5,7 +5,7 @@ import { getErrors } from "../../json-schema-errors.js";
  */
 
 /** @type ErrorHandler */
-const dependenciesErrorHandler = async (normalizedErrors, instance, localization) => {
+const dependenciesErrorHandler = (normalizedErrors, instance, localization, resolver) => {
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -16,7 +16,7 @@ const dependenciesErrorHandler = async (normalizedErrors, instance, localization
 
     const dependentSchemaOutputs = normalizedErrors["https://json-schema.org/keyword/draft-04/dependencies"][schemaLocation];
     for (const dependentSchemaOutput of dependentSchemaOutputs) {
-      const dependentSchemaErrors = await getErrors(dependentSchemaOutput, instance, localization);
+      const dependentSchemaErrors = getErrors(dependentSchemaOutput, instance, localization, resolver);
       errors.push(...dependentSchemaErrors);
     }
   }

--- a/src/error-handlers/draft-04/dependencies.js
+++ b/src/error-handlers/draft-04/dependencies.js
@@ -5,7 +5,7 @@ import { getErrors } from "../../json-schema-errors.js";
  */
 
 /** @type ErrorHandler */
-const dependenciesErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const dependenciesErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -16,7 +16,7 @@ const dependenciesErrorHandler = (normalizedErrors, instance, localization, reso
 
     const dependentSchemaOutputs = normalizedErrors["https://json-schema.org/keyword/draft-04/dependencies"][schemaLocation];
     for (const dependentSchemaOutput of dependentSchemaOutputs) {
-      const dependentSchemaErrors = getErrors(dependentSchemaOutput, instance, localization, resolver);
+      const dependentSchemaErrors = getErrors(dependentSchemaOutput, instance, localization, ast);
       errors.push(...dependentSchemaErrors);
     }
   }

--- a/src/error-handlers/format.js
+++ b/src/error-handlers/format.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -7,7 +5,11 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const formatErrorHandler = async (normalizedErrors, instance, localization) => {
+const formatErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  if (!resolver?.getCompiledKeywordValue) {
+    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
+  }
+
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -26,8 +28,7 @@ const formatErrorHandler = async (normalizedErrors, instance, localization) => {
         continue;
       }
 
-      const keyword = await getSchema(schemaLocation);
-      const format = /** @type string */ (Schema.value(keyword));
+      const format = /** @type string */ (resolver.getCompiledKeywordValue(schemaLocation));
 
       errors.push({
         message: localization.getFormatErrorMessage(format),

--- a/src/error-handlers/format.js
+++ b/src/error-handlers/format.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const formatErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue) {
-    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
-  }
-
   /** @type ErrorObject[] */
   const errors = [];
 

--- a/src/error-handlers/format.js
+++ b/src/error-handlers/format.js
@@ -1,11 +1,12 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler, ErrorObject } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
-const formatErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const formatErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -24,7 +25,7 @@ const formatErrorHandler = (normalizedErrors, instance, localization, resolver) 
         continue;
       }
 
-      const format = /** @type string */ (resolver.getCompiledKeywordValue(schemaLocation));
+      const format = /** @type string */ (getCompiledKeywordValue(ast, schemaLocation));
 
       errors.push({
         message: localization.getFormatErrorMessage(format),

--- a/src/error-handlers/maxItems.js
+++ b/src/error-handlers/maxItems.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -7,7 +5,11 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const maxItemsErrorHandler = async (normalizedErrors, instance, localization) => {
+const maxItemsErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  if (!resolver?.getCompiledKeywordValue) {
+    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
+  }
+
   /** @type ErrorObject[] */
   const errors = [];
   let lowestMaxItems = Infinity;
@@ -18,8 +20,7 @@ const maxItemsErrorHandler = async (normalizedErrors, instance, localization) =>
       continue;
     }
 
-    const keyword = await getSchema(schemaLocation);
-    const maxItems = /** @type number */ (Schema.value(keyword));
+    const maxItems = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
 
     if (maxItems < lowestMaxItems) {
       lowestMaxItems = maxItems;

--- a/src/error-handlers/maxItems.js
+++ b/src/error-handlers/maxItems.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const maxItemsErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue) {
-    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
-  }
-
   /** @type ErrorObject[] */
   const errors = [];
   let lowestMaxItems = Infinity;

--- a/src/error-handlers/maxItems.js
+++ b/src/error-handlers/maxItems.js
@@ -1,11 +1,12 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler, ErrorObject } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
-const maxItemsErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const maxItemsErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
   let lowestMaxItems = Infinity;
@@ -16,7 +17,7 @@ const maxItemsErrorHandler = (normalizedErrors, instance, localization, resolver
       continue;
     }
 
-    const maxItems = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const maxItems = /** @type number */ (getCompiledKeywordValue(ast, schemaLocation));
 
     if (maxItems < lowestMaxItems) {
       lowestMaxItems = maxItems;

--- a/src/error-handlers/maxLength.js
+++ b/src/error-handlers/maxLength.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const maxLengthErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue) {
-    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
-  }
-
   /** @type ErrorObject[] */
   const errors = [];
   let lowestMaxLength = Infinity;

--- a/src/error-handlers/maxLength.js
+++ b/src/error-handlers/maxLength.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -7,7 +5,11 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const maxLengthErrorHandler = async (normalizedErrors, instance, localization) => {
+const maxLengthErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  if (!resolver?.getCompiledKeywordValue) {
+    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
+  }
+
   /** @type ErrorObject[] */
   const errors = [];
   let lowestMaxLength = Infinity;
@@ -18,8 +20,7 @@ const maxLengthErrorHandler = async (normalizedErrors, instance, localization) =
       continue;
     }
 
-    const keyword = await getSchema(schemaLocation);
-    const maxLength = /** @type number */ (Schema.value(keyword));
+    const maxLength = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
 
     if (maxLength < lowestMaxLength) {
       lowestMaxLength = maxLength;

--- a/src/error-handlers/maxLength.js
+++ b/src/error-handlers/maxLength.js
@@ -1,11 +1,12 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler, ErrorObject } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
-const maxLengthErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const maxLengthErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
   let lowestMaxLength = Infinity;
@@ -16,7 +17,7 @@ const maxLengthErrorHandler = (normalizedErrors, instance, localization, resolve
       continue;
     }
 
-    const maxLength = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const maxLength = /** @type number */ (getCompiledKeywordValue(ast, schemaLocation));
 
     if (maxLength < lowestMaxLength) {
       lowestMaxLength = maxLength;

--- a/src/error-handlers/maxProperties.js
+++ b/src/error-handlers/maxProperties.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const maxPropertiesErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue) {
-    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
-  }
-
   /** @type ErrorObject[] */
   const errors = [];
   let lowestMaxProperties = Infinity;

--- a/src/error-handlers/maxProperties.js
+++ b/src/error-handlers/maxProperties.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -7,7 +5,11 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const maxPropertiesErrorHandler = async (normalizedErrors, instance, localization) => {
+const maxPropertiesErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  if (!resolver?.getCompiledKeywordValue) {
+    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
+  }
+
   /** @type ErrorObject[] */
   const errors = [];
   let lowestMaxProperties = Infinity;
@@ -17,8 +19,7 @@ const maxPropertiesErrorHandler = async (normalizedErrors, instance, localizatio
       continue;
     }
 
-    const keyword = await getSchema(schemaLocation);
-    const maxProperties = /** @type number */ (Schema.value(keyword));
+    const maxProperties = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
 
     if (maxProperties < lowestMaxProperties) {
       lowestMaxProperties = maxProperties;

--- a/src/error-handlers/maxProperties.js
+++ b/src/error-handlers/maxProperties.js
@@ -1,11 +1,12 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler, ErrorObject } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
-const maxPropertiesErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const maxPropertiesErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
   let lowestMaxProperties = Infinity;
@@ -15,7 +16,7 @@ const maxPropertiesErrorHandler = (normalizedErrors, instance, localization, res
       continue;
     }
 
-    const maxProperties = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const maxProperties = /** @type number */ (getCompiledKeywordValue(ast, schemaLocation));
 
     if (maxProperties < lowestMaxProperties) {
       lowestMaxProperties = maxProperties;

--- a/src/error-handlers/maximum.js
+++ b/src/error-handlers/maximum.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -7,7 +5,16 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const maximumErrorHandler = async (normalizedErrors, instance, localization) => {
+const maximumErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  /** @type {{
+   *   getCompiledKeywordValue?: (schemaLocation: string) => unknown;
+   *   getSiblingKeywordValue?: (schemaLocation: string, siblingKeywordUri: string) =>
+   *     { keywordLocation: string; keywordValue: unknown } | undefined
+   * } | undefined} */
+  if (!resolver?.getCompiledKeywordValue || !resolver.getSiblingKeywordValue) {
+    throw new Error("Missing resolver functions in error handler context");
+  }
+
   let lowestMaximum = Infinity;
   let isExclusive = false;
 
@@ -19,8 +26,7 @@ const maximumErrorHandler = async (normalizedErrors, instance, localization) => 
       continue;
     }
 
-    const keyword = await getSchema(schemaLocation);
-    const maximum = /** @type number */ (Schema.value(keyword));
+    const maximum = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
     if (maximum < lowestMaximum) {
       lowestMaximum = maximum;
       schemaLocations = [schemaLocation];
@@ -32,8 +38,7 @@ const maximumErrorHandler = async (normalizedErrors, instance, localization) => 
       continue;
     }
 
-    const keyword = await getSchema(schemaLocation);
-    const exclusiveMaximum = /** @type number */ (Schema.value(keyword));
+    const exclusiveMaximum = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
     if (exclusiveMaximum < lowestMaximum) {
       lowestMaximum = exclusiveMaximum;
       isExclusive = true;
@@ -46,26 +51,15 @@ const maximumErrorHandler = async (normalizedErrors, instance, localization) => 
       continue;
     }
 
-    const parentLocation = pointerPop(schemaLocation);
-    /** @type string */
-    let exclusiveLocation = "";
-    for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/draft-04/exclusiveMaximum"]) {
-      const exclusiveParentLocation = pointerPop(schemaLocation);
-      if (exclusiveParentLocation === parentLocation) {
-        const exclusiveNode = await getSchema(schemaLocation);
-        if (Schema.value(exclusiveNode)) {
-          exclusiveLocation = schemaLocation;
-        }
-        break;
-      }
-    }
-
-    const keywordNode = await getSchema(schemaLocation);
-    const maximum = /** @type number */ (Schema.value(keywordNode));
+    const draft04Maximum = /** @type [number, boolean] */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const maximum = draft04Maximum[0];
+    const exclusive = draft04Maximum[1];
+    const exclusiveKeyword = resolver.getSiblingKeywordValue(schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMaximum");
+    const exclusiveLocation = exclusive && exclusiveKeyword ? exclusiveKeyword.keywordLocation : "";
 
     if (maximum < lowestMaximum) {
       lowestMaximum = maximum;
-      isExclusive = !!exclusiveLocation;
+      isExclusive = exclusive;
       schemaLocations = exclusiveLocation ? [schemaLocation, exclusiveLocation] : [schemaLocation];
     }
   }
@@ -86,8 +80,5 @@ const maximumErrorHandler = async (normalizedErrors, instance, localization) => 
     }];
   }
 };
-
-/** @type (pointer: string) => string */
-const pointerPop = (pointer) => pointer.replace(/\/[^/]+$/, "");
 
 export default maximumErrorHandler;

--- a/src/error-handlers/maximum.js
+++ b/src/error-handlers/maximum.js
@@ -1,5 +1,5 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
-import { getCompiledKeywordValue, getSiblingKeywordValue } from "../json-schema-errors.js";
+import { getCompiledKeywordValue, getSiblingKeywordLocation } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler } from "../index.d.ts"
@@ -46,12 +46,11 @@ const maximumErrorHandler = (normalizedErrors, instance, localization, ast) => {
     const draft04Maximum = /** @type [number, boolean] */ (getCompiledKeywordValue(ast, schemaLocation));
     const maximum = draft04Maximum[0];
     const exclusive = draft04Maximum[1];
-    const exclusiveKeywordLocation = getSiblingKeywordValue(ast, schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMaximum");
-    const exclusiveLocation = exclusive && exclusiveKeywordLocation ? exclusiveKeywordLocation : "";
 
     if (maximum < lowestMaximum) {
       lowestMaximum = maximum;
       isExclusive = exclusive;
+      const exclusiveLocation = exclusive ? getSiblingKeywordLocation(ast, schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMaximum") : "";
       schemaLocations = exclusiveLocation ? [schemaLocation, exclusiveLocation] : [schemaLocation];
     }
   }

--- a/src/error-handlers/maximum.js
+++ b/src/error-handlers/maximum.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const maximumErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue || !resolver.getSiblingKeywordValue) {
-    throw new Error("Missing resolver functions in error handler context");
-  }
-
   let lowestMaximum = Infinity;
   let isExclusive = false;
 

--- a/src/error-handlers/maximum.js
+++ b/src/error-handlers/maximum.js
@@ -43,15 +43,15 @@ const maximumErrorHandler = (normalizedErrors, instance, localization, ast) => {
       continue;
     }
 
-    const draft04Maximum = /** @type [number, boolean] */ (getCompiledKeywordValue(ast, schemaLocation));
-    const maximum = draft04Maximum[0];
-    const exclusive = draft04Maximum[1];
-
+    const [maximum, exclusive] = /** @type [number, boolean] */ (getCompiledKeywordValue(ast, schemaLocation));
     if (maximum < lowestMaximum) {
       lowestMaximum = maximum;
       isExclusive = exclusive;
-      const exclusiveLocation = exclusive ? getSiblingKeywordLocation(ast, schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMaximum") : "";
-      schemaLocations = exclusiveLocation ? [schemaLocation, exclusiveLocation] : [schemaLocation];
+      schemaLocations = [schemaLocation];
+      if (exclusive) {
+        const exclusiveLocation = getSiblingKeywordLocation(ast, schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMaximum");
+        schemaLocations.push(exclusiveLocation);
+      }
     }
   }
 

--- a/src/error-handlers/maximum.js
+++ b/src/error-handlers/maximum.js
@@ -6,11 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const maximumErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  /** @type {{
-   *   getCompiledKeywordValue?: (schemaLocation: string) => unknown;
-   *   getSiblingKeywordValue?: (schemaLocation: string, siblingKeywordUri: string) =>
-   *     { keywordLocation: string; keywordValue: unknown } | undefined
-   * } | undefined} */
   if (!resolver?.getCompiledKeywordValue || !resolver.getSiblingKeywordValue) {
     throw new Error("Missing resolver functions in error handler context");
   }

--- a/src/error-handlers/maximum.js
+++ b/src/error-handlers/maximum.js
@@ -1,11 +1,12 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue, getSiblingKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
-const maximumErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const maximumErrorHandler = (normalizedErrors, instance, localization, ast) => {
   let lowestMaximum = Infinity;
   let isExclusive = false;
 
@@ -17,7 +18,7 @@ const maximumErrorHandler = (normalizedErrors, instance, localization, resolver)
       continue;
     }
 
-    const maximum = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const maximum = /** @type number */ (getCompiledKeywordValue(ast, schemaLocation));
     if (maximum < lowestMaximum) {
       lowestMaximum = maximum;
       schemaLocations = [schemaLocation];
@@ -29,7 +30,7 @@ const maximumErrorHandler = (normalizedErrors, instance, localization, resolver)
       continue;
     }
 
-    const exclusiveMaximum = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const exclusiveMaximum = /** @type number */ (getCompiledKeywordValue(ast, schemaLocation));
     if (exclusiveMaximum < lowestMaximum) {
       lowestMaximum = exclusiveMaximum;
       isExclusive = true;
@@ -42,11 +43,11 @@ const maximumErrorHandler = (normalizedErrors, instance, localization, resolver)
       continue;
     }
 
-    const draft04Maximum = /** @type [number, boolean] */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const draft04Maximum = /** @type [number, boolean] */ (getCompiledKeywordValue(ast, schemaLocation));
     const maximum = draft04Maximum[0];
     const exclusive = draft04Maximum[1];
-    const exclusiveKeyword = resolver.getSiblingKeywordValue(schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMaximum");
-    const exclusiveLocation = exclusive && exclusiveKeyword ? exclusiveKeyword.keywordLocation : "";
+    const exclusiveKeywordLocation = getSiblingKeywordValue(ast, schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMaximum");
+    const exclusiveLocation = exclusive && exclusiveKeywordLocation ? exclusiveKeywordLocation : "";
 
     if (maximum < lowestMaximum) {
       lowestMaximum = maximum;

--- a/src/error-handlers/minItems.js
+++ b/src/error-handlers/minItems.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -7,7 +5,11 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const minItemsErrorHandler = async (normalizedErrors, instance, localization) => {
+const minItemsErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  if (!resolver?.getCompiledKeywordValue) {
+    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
+  }
+
   /** @type ErrorObject[] */
   const errors = [];
   let highestMinItem = 0;
@@ -18,8 +20,7 @@ const minItemsErrorHandler = async (normalizedErrors, instance, localization) =>
       continue;
     }
 
-    const keyword = await getSchema(schemaLocation);
-    const minItems = /** @type number */ (Schema.value(keyword));
+    const minItems = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
 
     if (minItems > highestMinItem) {
       highestMinItem = minItems;

--- a/src/error-handlers/minItems.js
+++ b/src/error-handlers/minItems.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const minItemsErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue) {
-    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
-  }
-
   /** @type ErrorObject[] */
   const errors = [];
   let highestMinItem = 0;

--- a/src/error-handlers/minItems.js
+++ b/src/error-handlers/minItems.js
@@ -1,11 +1,12 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler, ErrorObject } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
-const minItemsErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const minItemsErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
   let highestMinItem = 0;
@@ -16,7 +17,7 @@ const minItemsErrorHandler = (normalizedErrors, instance, localization, resolver
       continue;
     }
 
-    const minItems = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const minItems = /** @type number */ (getCompiledKeywordValue(ast, schemaLocation));
 
     if (minItems > highestMinItem) {
       highestMinItem = minItems;

--- a/src/error-handlers/minLength.js
+++ b/src/error-handlers/minLength.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const minLengthErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue) {
-    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
-  }
-
   /** @type ErrorObject[] */
   const errors = [];
   let highestMinLength = -Infinity;

--- a/src/error-handlers/minLength.js
+++ b/src/error-handlers/minLength.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -7,7 +5,11 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const minLengthErrorHandler = async (normalizedErrors, instance, localization) => {
+const minLengthErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  if (!resolver?.getCompiledKeywordValue) {
+    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
+  }
+
   /** @type ErrorObject[] */
   const errors = [];
   let highestMinLength = -Infinity;
@@ -18,8 +20,7 @@ const minLengthErrorHandler = async (normalizedErrors, instance, localization) =
       continue;
     }
 
-    const keyword = await getSchema(schemaLocation);
-    const minLength = /** @type number */ (Schema.value(keyword));
+    const minLength = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
 
     if (minLength > highestMinLength) {
       highestMinLength = minLength;

--- a/src/error-handlers/minLength.js
+++ b/src/error-handlers/minLength.js
@@ -1,11 +1,12 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler, ErrorObject } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
-const minLengthErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const minLengthErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
   let highestMinLength = -Infinity;
@@ -16,7 +17,7 @@ const minLengthErrorHandler = (normalizedErrors, instance, localization, resolve
       continue;
     }
 
-    const minLength = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const minLength = /** @type number */ (getCompiledKeywordValue(ast, schemaLocation));
 
     if (minLength > highestMinLength) {
       highestMinLength = minLength;

--- a/src/error-handlers/minProperties.js
+++ b/src/error-handlers/minProperties.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -7,7 +5,11 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const minPropertiesErrorHandler = async (normalizedErrors, instance, localization) => {
+const minPropertiesErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  if (!resolver?.getCompiledKeywordValue) {
+    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
+  }
+
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -19,8 +21,7 @@ const minPropertiesErrorHandler = async (normalizedErrors, instance, localizatio
       continue;
     }
 
-    const keyword = await getSchema(schemaLocation);
-    const minProperties = /** @type number */ (Schema.value(keyword));
+    const minProperties = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
 
     if (minProperties > highestMinProperties) {
       highestMinProperties = minProperties;

--- a/src/error-handlers/minProperties.js
+++ b/src/error-handlers/minProperties.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const minPropertiesErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue) {
-    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
-  }
-
   /** @type ErrorObject[] */
   const errors = [];
 

--- a/src/error-handlers/minProperties.js
+++ b/src/error-handlers/minProperties.js
@@ -1,11 +1,12 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler, ErrorObject } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
-const minPropertiesErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const minPropertiesErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -17,7 +18,7 @@ const minPropertiesErrorHandler = (normalizedErrors, instance, localization, res
       continue;
     }
 
-    const minProperties = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const minProperties = /** @type number */ (getCompiledKeywordValue(ast, schemaLocation));
 
     if (minProperties > highestMinProperties) {
       highestMinProperties = minProperties;

--- a/src/error-handlers/minimum.js
+++ b/src/error-handlers/minimum.js
@@ -1,5 +1,5 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
-import { getCompiledKeywordValue, getSiblingKeywordValue } from "../json-schema-errors.js";
+import { getCompiledKeywordValue, getSiblingKeywordLocation } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler } from "../index.d.ts"
@@ -47,11 +47,10 @@ const minimumErrorHandler = (normalizedErrors, instance, localization, ast) => {
     const draft04Minimum = /** @type [number, boolean] */ (getCompiledKeywordValue(ast, schemaLocation));
     const minimum = draft04Minimum[0];
     const exclusive = draft04Minimum[1];
-    const exclusiveKeywordLocation = getSiblingKeywordValue(ast, schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMinimum");
-    const exclusiveLocation = exclusive && exclusiveKeywordLocation ? exclusiveKeywordLocation : "";
     if (minimum > highestMinimum) {
       highestMinimum = minimum;
       isExclusive = exclusive;
+      const exclusiveLocation = exclusive ? getSiblingKeywordLocation(ast, schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMinimum") : "";
       schemaLocations = exclusiveLocation ? [schemaLocation, exclusiveLocation] : [schemaLocation];
     }
   }

--- a/src/error-handlers/minimum.js
+++ b/src/error-handlers/minimum.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const minimumErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue || !resolver.getSiblingKeywordValue) {
-    throw new Error("Missing resolver functions in error handler context");
-  }
-
   let highestMinimum = -Infinity;
   let isExclusive = false;
   /** @type string[] */

--- a/src/error-handlers/minimum.js
+++ b/src/error-handlers/minimum.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -7,7 +5,16 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const minimumErrorHandler = async (normalizedErrors, instance, localization) => {
+const minimumErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  /** @type {{
+   *   getCompiledKeywordValue?: (schemaLocation: string) => unknown;
+   *   getSiblingKeywordValue?: (schemaLocation: string, siblingKeywordUri: string) =>
+   *     { keywordLocation: string; keywordValue: unknown } | undefined
+   * } | undefined} */
+  if (!resolver?.getCompiledKeywordValue || !resolver.getSiblingKeywordValue) {
+    throw new Error("Missing resolver functions in error handler context");
+  }
+
   let highestMinimum = -Infinity;
   let isExclusive = false;
   /** @type string[] */
@@ -18,8 +25,7 @@ const minimumErrorHandler = async (normalizedErrors, instance, localization) => 
       continue;
     }
 
-    const keyword = await getSchema(schemaLocation);
-    const minimum = /** @type number */ (Schema.value(keyword));
+    const minimum = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
 
     if (minimum > highestMinimum) {
       highestMinimum = minimum;
@@ -33,8 +39,7 @@ const minimumErrorHandler = async (normalizedErrors, instance, localization) => 
       continue;
     }
 
-    const keyword = await getSchema(schemaLocation);
-    const exclusiveMinimum = /** @type number */ (Schema.value(keyword));
+    const exclusiveMinimum = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
 
     if (exclusiveMinimum > highestMinimum) {
       highestMinimum = exclusiveMinimum;
@@ -47,25 +52,14 @@ const minimumErrorHandler = async (normalizedErrors, instance, localization) => 
       continue;
     }
 
-    const parentLocation = pointerPop(schemaLocation);
-
-    let exclusiveLocation = "";
-    for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/draft-04/exclusiveMinimum"]) {
-      const exclusiveParentLocation = pointerPop(schemaLocation);
-      if (exclusiveParentLocation === parentLocation) {
-        const exclusiveNode = await getSchema(schemaLocation);
-        if (Schema.value(exclusiveNode)) {
-          exclusiveLocation = schemaLocation;
-        }
-        break;
-      }
-    }
-
-    const keywordNode = await getSchema(schemaLocation);
-    const minimum = /** @type number */ (Schema.value(keywordNode));
+    const draft04Minimum = /** @type [number, boolean] */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const minimum = draft04Minimum[0];
+    const exclusive = draft04Minimum[1];
+    const exclusiveKeyword = resolver.getSiblingKeywordValue(schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMinimum");
+    const exclusiveLocation = exclusive && exclusiveKeyword ? exclusiveKeyword.keywordLocation : "";
     if (minimum > highestMinimum) {
       highestMinimum = minimum;
-      isExclusive = !!exclusiveLocation;
+      isExclusive = exclusive;
       schemaLocations = exclusiveLocation ? [schemaLocation, exclusiveLocation] : [schemaLocation];
     }
   }
@@ -86,8 +80,5 @@ const minimumErrorHandler = async (normalizedErrors, instance, localization) => 
     }];
   }
 };
-
-/** @type (pointer: string) => string */
-const pointerPop = (pointer) => pointer.replace(/\/[^/]+$/, "");
 
 export default minimumErrorHandler;

--- a/src/error-handlers/minimum.js
+++ b/src/error-handlers/minimum.js
@@ -39,19 +39,21 @@ const minimumErrorHandler = (normalizedErrors, instance, localization, ast) => {
       schemaLocations = [schemaLocation];
     }
   }
+
   for (const schemaLocation in normalizedErrors["https://json-schema.org/keyword/draft-04/minimum"]) {
     if (normalizedErrors["https://json-schema.org/keyword/draft-04/minimum"][schemaLocation]) {
       continue;
     }
 
-    const draft04Minimum = /** @type [number, boolean] */ (getCompiledKeywordValue(ast, schemaLocation));
-    const minimum = draft04Minimum[0];
-    const exclusive = draft04Minimum[1];
+    const [minimum, exclusive] = /** @type [number, boolean] */ (getCompiledKeywordValue(ast, schemaLocation));
     if (minimum > highestMinimum) {
       highestMinimum = minimum;
       isExclusive = exclusive;
-      const exclusiveLocation = exclusive ? getSiblingKeywordLocation(ast, schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMinimum") : "";
-      schemaLocations = exclusiveLocation ? [schemaLocation, exclusiveLocation] : [schemaLocation];
+      schemaLocations = [schemaLocation];
+      if (exclusive) {
+        const exclusiveLocation = getSiblingKeywordLocation(ast, schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMinimum");
+        schemaLocations.push(exclusiveLocation);
+      }
     }
   }
 

--- a/src/error-handlers/minimum.js
+++ b/src/error-handlers/minimum.js
@@ -1,11 +1,12 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue, getSiblingKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
-const minimumErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const minimumErrorHandler = (normalizedErrors, instance, localization, ast) => {
   let highestMinimum = -Infinity;
   let isExclusive = false;
   /** @type string[] */
@@ -16,7 +17,7 @@ const minimumErrorHandler = (normalizedErrors, instance, localization, resolver)
       continue;
     }
 
-    const minimum = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const minimum = /** @type number */ (getCompiledKeywordValue(ast, schemaLocation));
 
     if (minimum > highestMinimum) {
       highestMinimum = minimum;
@@ -30,7 +31,7 @@ const minimumErrorHandler = (normalizedErrors, instance, localization, resolver)
       continue;
     }
 
-    const exclusiveMinimum = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const exclusiveMinimum = /** @type number */ (getCompiledKeywordValue(ast, schemaLocation));
 
     if (exclusiveMinimum > highestMinimum) {
       highestMinimum = exclusiveMinimum;
@@ -43,11 +44,11 @@ const minimumErrorHandler = (normalizedErrors, instance, localization, resolver)
       continue;
     }
 
-    const draft04Minimum = /** @type [number, boolean] */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const draft04Minimum = /** @type [number, boolean] */ (getCompiledKeywordValue(ast, schemaLocation));
     const minimum = draft04Minimum[0];
     const exclusive = draft04Minimum[1];
-    const exclusiveKeyword = resolver.getSiblingKeywordValue(schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMinimum");
-    const exclusiveLocation = exclusive && exclusiveKeyword ? exclusiveKeyword.keywordLocation : "";
+    const exclusiveKeywordLocation = getSiblingKeywordValue(ast, schemaLocation, "https://json-schema.org/keyword/draft-04/exclusiveMinimum");
+    const exclusiveLocation = exclusive && exclusiveKeywordLocation ? exclusiveKeywordLocation : "";
     if (minimum > highestMinimum) {
       highestMinimum = minimum;
       isExclusive = exclusive;

--- a/src/error-handlers/minimum.js
+++ b/src/error-handlers/minimum.js
@@ -6,11 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const minimumErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  /** @type {{
-   *   getCompiledKeywordValue?: (schemaLocation: string) => unknown;
-   *   getSiblingKeywordValue?: (schemaLocation: string, siblingKeywordUri: string) =>
-   *     { keywordLocation: string; keywordValue: unknown } | undefined
-   * } | undefined} */
   if (!resolver?.getCompiledKeywordValue || !resolver.getSiblingKeywordValue) {
     throw new Error("Missing resolver functions in error handler context");
   }

--- a/src/error-handlers/multipleOf.js
+++ b/src/error-handlers/multipleOf.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -7,7 +5,11 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const multipleOfErrorHandler = async (normalizedErrors, instance, localization) => {
+const multipleOfErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  if (!resolver?.getCompiledKeywordValue) {
+    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
+  }
+
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -22,8 +24,7 @@ const multipleOfErrorHandler = async (normalizedErrors, instance, localization) 
       hasError = true;
     }
 
-    const keyword = await getSchema(schemaLocation);
-    const multipleOf = /** @type number */ (Schema.value(keyword));
+    const multipleOf = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
 
     combinedMultipleOf = combinedMultipleOf === null ? multipleOf : lcm(combinedMultipleOf, multipleOf);
     schemaLocations.push(schemaLocation);

--- a/src/error-handlers/multipleOf.js
+++ b/src/error-handlers/multipleOf.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const multipleOfErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue) {
-    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
-  }
-
   /** @type ErrorObject[] */
   const errors = [];
 

--- a/src/error-handlers/multipleOf.js
+++ b/src/error-handlers/multipleOf.js
@@ -1,11 +1,12 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler, ErrorObject } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
-const multipleOfErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const multipleOfErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -20,7 +21,7 @@ const multipleOfErrorHandler = (normalizedErrors, instance, localization, resolv
       hasError = true;
     }
 
-    const multipleOf = /** @type number */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const multipleOf = /** @type number */ (getCompiledKeywordValue(ast, schemaLocation));
 
     combinedMultipleOf = combinedMultipleOf === null ? multipleOf : lcm(combinedMultipleOf, multipleOf);
     schemaLocations.push(schemaLocation);

--- a/src/error-handlers/not.js
+++ b/src/error-handlers/not.js
@@ -5,7 +5,7 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const notErrorHandler = async (normalizedErrors, instance, localization) => {
+const notErrorHandler = (normalizedErrors, instance, localization) => {
   /** @type ErrorObject[] */
   const errors = [];
 

--- a/src/error-handlers/oneOf.js
+++ b/src/error-handlers/oneOf.js
@@ -7,7 +7,7 @@ import { getErrors } from "../json-schema-errors.js";
  */
 
 /** @type ErrorHandler */
-const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
+const oneOfErrorHandler = (normalizedErrors, instance, localization, resolver) => {
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -51,7 +51,7 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
       }
 
       // The alternative passed all the filters
-      const alternativeErrors = await getErrors(alternative, instance, localization);
+      const alternativeErrors = getErrors(alternative, instance, localization, resolver);
       if (alternativeErrors.length) {
         alternatives.push(alternativeErrors);
       } else {
@@ -61,7 +61,7 @@ const oneOfErrorHandler = async (normalizedErrors, instance, localization) => {
 
     if (matchCount === 0 && alternatives.length === 0) {
       for (const alternative of oneOf) {
-        const alternativeErrors = await getErrors(alternative, instance, localization);
+        const alternativeErrors = getErrors(alternative, instance, localization, resolver);
         alternatives.push(alternativeErrors);
       }
     }

--- a/src/error-handlers/oneOf.js
+++ b/src/error-handlers/oneOf.js
@@ -7,7 +7,7 @@ import { getErrors } from "../json-schema-errors.js";
  */
 
 /** @type ErrorHandler */
-const oneOfErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const oneOfErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -51,7 +51,7 @@ const oneOfErrorHandler = (normalizedErrors, instance, localization, resolver) =
       }
 
       // The alternative passed all the filters
-      const alternativeErrors = getErrors(alternative, instance, localization, resolver);
+      const alternativeErrors = getErrors(alternative, instance, localization, ast);
       if (alternativeErrors.length) {
         alternatives.push(alternativeErrors);
       } else {
@@ -61,7 +61,7 @@ const oneOfErrorHandler = (normalizedErrors, instance, localization, resolver) =
 
     if (matchCount === 0 && alternatives.length === 0) {
       for (const alternative of oneOf) {
-        const alternativeErrors = getErrors(alternative, instance, localization, resolver);
+        const alternativeErrors = getErrors(alternative, instance, localization, ast);
         alternatives.push(alternativeErrors);
       }
     }

--- a/src/error-handlers/pattern.js
+++ b/src/error-handlers/pattern.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -7,7 +5,11 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const patternErrorHandler = async (normalizedErrors, instance, localization) => {
+const patternErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  if (!resolver?.getCompiledKeywordValue) {
+    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
+  }
+
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -16,8 +18,8 @@ const patternErrorHandler = async (normalizedErrors, instance, localization) => 
       continue;
     }
 
-    const keyword = await getSchema(schemaLocation);
-    const pattern = /** @type string */ (Schema.value(keyword));
+    const compiledPattern = resolver.getCompiledKeywordValue(schemaLocation);
+    const pattern = typeof compiledPattern === "string" ? compiledPattern : /** @type RegExp */ (compiledPattern).source;
 
     errors.push({
       message: localization.getPatternErrorMessage(pattern),

--- a/src/error-handlers/pattern.js
+++ b/src/error-handlers/pattern.js
@@ -6,10 +6,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const patternErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue) {
-    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
-  }
-
   /** @type ErrorObject[] */
   const errors = [];
 

--- a/src/error-handlers/pattern.js
+++ b/src/error-handlers/pattern.js
@@ -15,7 +15,7 @@ const patternErrorHandler = (normalizedErrors, instance, localization, resolver)
     }
 
     const compiledPattern = resolver.getCompiledKeywordValue(schemaLocation);
-    const pattern = typeof compiledPattern === "string" ? compiledPattern : /** @type RegExp */ (compiledPattern).source;
+    const pattern = /** @type RegExp */ (compiledPattern).source;
 
     errors.push({
       message: localization.getPatternErrorMessage(pattern),

--- a/src/error-handlers/pattern.js
+++ b/src/error-handlers/pattern.js
@@ -1,11 +1,12 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler, ErrorObject } from "../index.d.ts"
  */
 
 /** @type ErrorHandler */
-const patternErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const patternErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type ErrorObject[] */
   const errors = [];
 
@@ -14,8 +15,8 @@ const patternErrorHandler = (normalizedErrors, instance, localization, resolver)
       continue;
     }
 
-    const compiledPattern = resolver.getCompiledKeywordValue(schemaLocation);
-    const pattern = /** @type RegExp */ (compiledPattern).source;
+    const compiledPattern = /** @type RegExp */ (getCompiledKeywordValue(ast, schemaLocation));
+    const pattern = compiledPattern.source;
 
     errors.push({
       message: localization.getPatternErrorMessage(pattern),

--- a/src/error-handlers/required.js
+++ b/src/error-handlers/required.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /**
@@ -8,7 +6,11 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const requiredErrorHandler = async (normalizedErrors, instance, localization) => {
+const requiredErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  if (!resolver?.getCompiledKeywordValue) {
+    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
+  }
+
   /** @type {Set<string>} */
   const allMissingRequired = new Set();
   const allSchemaLocations = [];
@@ -19,8 +21,7 @@ const requiredErrorHandler = async (normalizedErrors, instance, localization) =>
     }
 
     allSchemaLocations.push(schemaLocation);
-    const keyword = await getSchema(schemaLocation);
-    const required = /** @type string[] */ (Schema.value(keyword));
+    const required = /** @type string[] */ (resolver.getCompiledKeywordValue(schemaLocation));
 
     addMissingProperties(required, instance, allMissingRequired);
   }
@@ -31,14 +32,12 @@ const requiredErrorHandler = async (normalizedErrors, instance, localization) =>
     }
 
     allSchemaLocations.push(schemaLocation);
-    const keyword = await getSchema(schemaLocation);
+    const dependencies = /** @type {[string, string[]][]} */ (resolver.getCompiledKeywordValue(schemaLocation));
 
-    for await (const [propertyName, dependencyNode] of Schema.entries(keyword)) {
+    for (const [propertyName, requiredProperties] of dependencies) {
       if (!Instance.has(propertyName, instance)) {
         continue;
       }
-
-      const requiredProperties = /** @type string[] */ (Schema.value(dependencyNode));
       addMissingProperties(requiredProperties, instance, allMissingRequired);
     }
   }
@@ -48,16 +47,16 @@ const requiredErrorHandler = async (normalizedErrors, instance, localization) =>
       continue;
     }
 
-    const keyword = await getSchema(schemaLocation);
+    const dependencies = /** @type {[string, unknown][]} */ (resolver.getCompiledKeywordValue(schemaLocation));
 
     let hasArrayFormDependencies = false;
-    for await (const [propertyName, dependency] of Schema.entries(keyword)) {
-      if (!Instance.has(propertyName, instance) || Schema.typeOf(dependency) !== "array") {
+    for (const [propertyName, dependency] of dependencies) {
+      if (!Instance.has(propertyName, instance) || !Array.isArray(dependency)) {
         continue;
       }
 
       hasArrayFormDependencies = true;
-      const dependencyArray = /** @type {string[]} */ (Schema.value(dependency));
+      const dependencyArray = /** @type {string[]} */ (dependency);
       addMissingProperties(dependencyArray, instance, allMissingRequired);
     }
 

--- a/src/error-handlers/required.js
+++ b/src/error-handlers/required.js
@@ -7,10 +7,6 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 
 /** @type ErrorHandler */
 const requiredErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue) {
-    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
-  }
-
   /** @type {Set<string>} */
   const allMissingRequired = new Set();
   const allSchemaLocations = [];

--- a/src/error-handlers/required.js
+++ b/src/error-handlers/required.js
@@ -1,4 +1,5 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler } from "../index.d.ts"
@@ -6,7 +7,7 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
  */
 
 /** @type ErrorHandler */
-const requiredErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const requiredErrorHandler = (normalizedErrors, instance, localization, ast) => {
   /** @type {Set<string>} */
   const allMissingRequired = new Set();
   const allSchemaLocations = [];
@@ -17,7 +18,7 @@ const requiredErrorHandler = (normalizedErrors, instance, localization, resolver
     }
 
     allSchemaLocations.push(schemaLocation);
-    const required = /** @type string[] */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const required = /** @type string[] */ (getCompiledKeywordValue(ast, schemaLocation));
 
     addMissingProperties(required, instance, allMissingRequired);
   }
@@ -28,7 +29,7 @@ const requiredErrorHandler = (normalizedErrors, instance, localization, resolver
     }
 
     allSchemaLocations.push(schemaLocation);
-    const dependencies = /** @type {[string, string[]][]} */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const dependencies = /** @type {[string, string[]][]} */ (getCompiledKeywordValue(ast, schemaLocation));
 
     for (const [propertyName, requiredProperties] of dependencies) {
       if (!Instance.has(propertyName, instance)) {
@@ -43,7 +44,7 @@ const requiredErrorHandler = (normalizedErrors, instance, localization, resolver
       continue;
     }
 
-    const dependencies = /** @type {[string, unknown][]} */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const dependencies = /** @type {[string, unknown][]} */ (getCompiledKeywordValue(ast, schemaLocation));
 
     let hasArrayFormDependencies = false;
     for (const [propertyName, dependency] of dependencies) {

--- a/src/error-handlers/typeConstEnum.js
+++ b/src/error-handlers/typeConstEnum.js
@@ -8,10 +8,6 @@ const ALL_TYPES = new Set(["null", "boolean", "number", "string", "array", "obje
 
 /** @type {ErrorHandler} */
 const typeConstEnumErrorHandler = (normalizedErrors, instance, localization, resolver) => {
-  if (!resolver?.getCompiledKeywordValue) {
-    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
-  }
-
   let allowedTypes = new Set(ALL_TYPES);
   /** @type {string[]} */
   const failedTypeLocations = [];

--- a/src/error-handlers/typeConstEnum.js
+++ b/src/error-handlers/typeConstEnum.js
@@ -1,5 +1,3 @@
-import { getSchema } from "@hyperjump/json-schema/experimental";
-import * as Schema from "@hyperjump/browser";
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
 import jsonStringify from "json-stringify-deterministic";
 
@@ -10,7 +8,11 @@ import jsonStringify from "json-stringify-deterministic";
 const ALL_TYPES = new Set(["null", "boolean", "number", "string", "array", "object", "integer"]);
 
 /** @type {ErrorHandler} */
-const typeConstEnumErrorHandler = async (normalizedErrors, instance, localization) => {
+const typeConstEnumErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+  if (!resolver?.getCompiledKeywordValue) {
+    throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
+  }
+
   let allowedTypes = new Set(ALL_TYPES);
   /** @type {string[]} */
   const failedTypeLocations = [];
@@ -19,9 +21,8 @@ const typeConstEnumErrorHandler = async (normalizedErrors, instance, localizatio
     if (!normalizedErrors["https://json-schema.org/keyword/type"][schemaLocation]) {
       failedTypeLocations.push(schemaLocation);
 
-      const keyword = await getSchema(schemaLocation);
       /** @type {string | string[]} */
-      const value = Schema.value(keyword);
+      const value = /** @type {string | string[]} */ (resolver.getCompiledKeywordValue(schemaLocation));
       const types = Array.isArray(value) ? value : [value];
       /** @type {Set<string>} */
       const keywordTypes = new Set(types);
@@ -52,10 +53,11 @@ const typeConstEnumErrorHandler = async (normalizedErrors, instance, localizatio
       failedConstLocations.push(schemaLocation);
     }
 
-    const keyword = await getSchema(schemaLocation);
     const keywordJson = new Set();
-    if (allowedTypes.has(Schema.typeOf(keyword))) {
-      keywordJson.add(jsonStringify(Schema.value(keyword)));
+    const constValueJson = /** @type string */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const constValue = JSON.parse(constValueJson);
+    if (allowedTypes.has(jsonTypeOf(constValue))) {
+      keywordJson.add(constValueJson);
     } else {
       typeFiltered = true;
     }
@@ -69,11 +71,12 @@ const typeConstEnumErrorHandler = async (normalizedErrors, instance, localizatio
       failedEnumLocations.push(schemaLocation);
     }
 
-    const keyword = await getSchema(schemaLocation);
     const keywordJson = new Set();
-    for await (const enumValueNode of Schema.iter(keyword)) {
-      if (allowedTypes.has(Schema.typeOf(enumValueNode))) {
-        keywordJson.add(jsonStringify(Schema.value(enumValueNode)));
+    const enumValuesJson = /** @type string[] */ (resolver.getCompiledKeywordValue(schemaLocation));
+    for (const enumValueJson of enumValuesJson) {
+      const enumValue = JSON.parse(enumValueJson);
+      if (allowedTypes.has(jsonTypeOf(enumValue))) {
+        keywordJson.add(enumValueJson);
       } else {
         typeFiltered = true;
       }
@@ -112,6 +115,23 @@ const typeConstEnumErrorHandler = async (normalizedErrors, instance, localizatio
       schemaLocations: failedTypeLocations
     }];
   }
+};
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+const jsonTypeOf = (value) => {
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  if (typeof value === "number") {
+    return "number";
+  }
+  return typeof value;
 };
 
 export default typeConstEnumErrorHandler;

--- a/src/error-handlers/typeConstEnum.js
+++ b/src/error-handlers/typeConstEnum.js
@@ -1,4 +1,5 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
+import { getCompiledKeywordValue } from "../json-schema-errors.js";
 
 /**
  * @import { ErrorHandler, Json } from "../index.d.ts"
@@ -7,7 +8,7 @@ import * as Instance from "@hyperjump/json-schema/instance/experimental";
 const ALL_TYPES = new Set(["null", "boolean", "number", "string", "array", "object", "integer"]);
 
 /** @type {ErrorHandler} */
-const typeConstEnumErrorHandler = (normalizedErrors, instance, localization, resolver) => {
+const typeConstEnumErrorHandler = (normalizedErrors, instance, localization, ast) => {
   let allowedTypes = new Set(ALL_TYPES);
   /** @type {string[]} */
   const failedTypeLocations = [];
@@ -17,7 +18,7 @@ const typeConstEnumErrorHandler = (normalizedErrors, instance, localization, res
       failedTypeLocations.push(schemaLocation);
 
       /** @type {string | string[]} */
-      const value = /** @type {string | string[]} */ (resolver.getCompiledKeywordValue(schemaLocation));
+      const value = /** @type {string | string[]} */ (getCompiledKeywordValue(ast, schemaLocation));
       const types = Array.isArray(value) ? value : [value];
       /** @type {Set<string>} */
       const keywordTypes = new Set(types);
@@ -49,7 +50,7 @@ const typeConstEnumErrorHandler = (normalizedErrors, instance, localization, res
     }
 
     const keywordJson = new Set();
-    const constValueJson = /** @type string */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const constValueJson = /** @type string */ (getCompiledKeywordValue(ast, schemaLocation));
     if (allowedTypes.has(jsonTypeOf(constValueJson))) {
       keywordJson.add(constValueJson);
     } else {
@@ -66,7 +67,7 @@ const typeConstEnumErrorHandler = (normalizedErrors, instance, localization, res
     }
 
     const keywordJson = new Set();
-    const enumValuesJson = /** @type string[] */ (resolver.getCompiledKeywordValue(schemaLocation));
+    const enumValuesJson = /** @type string[] */ (getCompiledKeywordValue(ast, schemaLocation));
     for (const enumValueJson of enumValuesJson) {
       if (allowedTypes.has(jsonTypeOf(enumValueJson))) {
         keywordJson.add(enumValueJson);

--- a/src/error-handlers/typeConstEnum.js
+++ b/src/error-handlers/typeConstEnum.js
@@ -50,8 +50,7 @@ const typeConstEnumErrorHandler = (normalizedErrors, instance, localization, res
 
     const keywordJson = new Set();
     const constValueJson = /** @type string */ (resolver.getCompiledKeywordValue(schemaLocation));
-    const constValue = JSON.parse(constValueJson);
-    if (allowedTypes.has(jsonTypeOf(constValue))) {
+    if (allowedTypes.has(jsonTypeOf(constValueJson))) {
       keywordJson.add(constValueJson);
     } else {
       typeFiltered = true;
@@ -69,8 +68,7 @@ const typeConstEnumErrorHandler = (normalizedErrors, instance, localization, res
     const keywordJson = new Set();
     const enumValuesJson = /** @type string[] */ (resolver.getCompiledKeywordValue(schemaLocation));
     for (const enumValueJson of enumValuesJson) {
-      const enumValue = JSON.parse(enumValueJson);
-      if (allowedTypes.has(jsonTypeOf(enumValue))) {
+      if (allowedTypes.has(jsonTypeOf(enumValueJson))) {
         keywordJson.add(enumValueJson);
       } else {
         typeFiltered = true;
@@ -113,20 +111,24 @@ const typeConstEnumErrorHandler = (normalizedErrors, instance, localization, res
 };
 
 /**
- * @param {unknown} value
+ * @param {string} value
  * @returns {string}
  */
 const jsonTypeOf = (value) => {
-  if (value === null) {
+  const firstChar = value[0];
+  if (firstChar === "n") {
     return "null";
-  }
-  if (Array.isArray(value)) {
+  } else if (firstChar === "[") {
     return "array";
-  }
-  if (typeof value === "number") {
+  } else if ((firstChar >= "0" && firstChar <= "9") || firstChar === "-") {
     return "number";
+  } else if (firstChar === "{") {
+    return "object";
+  } else if (firstChar === "\"") {
+    return "string";
+  } else {
+    return "boolean";
   }
-  return typeof value;
 };
 
 export default typeConstEnumErrorHandler;

--- a/src/error-handlers/typeConstEnum.js
+++ b/src/error-handlers/typeConstEnum.js
@@ -1,5 +1,4 @@
 import * as Instance from "@hyperjump/json-schema/instance/experimental";
-import jsonStringify from "json-stringify-deterministic";
 
 /**
  * @import { ErrorHandler, Json } from "../index.d.ts"

--- a/src/error-handlers/uniqueItems.js
+++ b/src/error-handlers/uniqueItems.js
@@ -6,7 +6,7 @@ import jsonStringify from "json-stringify-deterministic";
  */
 
 /** @type ErrorHandler */
-const uniqueItemsErrorHandler = async (normalizedErrors, instance, localization) => {
+const uniqueItemsErrorHandler = (normalizedErrors, instance, localization) => {
   /** @type ErrorObject[] */
   const errors = [];
 

--- a/src/error-handlers/unknown.js
+++ b/src/error-handlers/unknown.js
@@ -6,7 +6,7 @@ import { pointerSegments } from "@hyperjump/json-pointer";
  */
 
 /** @type ErrorHandler */
-const unknownErrorHandler = async (normalizedErrors, instance, localization) => {
+const unknownErrorHandler = (normalizedErrors, instance, localization) => {
   /** @type ErrorObject[] */
   const errors = [];
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -154,13 +154,13 @@ export type ErrorResolver = {
  * A function that transforms normalized errors for one or more keywords into human
  * readable messages.
  */
-export type ErrorHandler = (normalizedErrors: InstanceOutput, instance: JsonNode, localization: Localization, resolver?: ErrorResolver) => ErrorObject[];
+export type ErrorHandler = (normalizedErrors: InstanceOutput, instance: JsonNode, localization: Localization, resolver: ErrorResolver) => ErrorObject[];
 
 /**
  * Converts the normalized error format to human readable errors. It's used to
  * build errors in applicator error handlers.
  */
-export const getErrors: (normalizedErrors: NormalizedOutput, instance: JsonNode, localization: Localization, resolver?: ErrorResolver) => ErrorObject[];
+export const getErrors: (normalizedErrors: NormalizedOutput, instance: JsonNode, localization: Localization, resolver: ErrorResolver) => ErrorObject[];
 
 export type { Localization };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -154,7 +154,7 @@ export type ErrorResolver = {
  * A function that transforms normalized errors for one or more keywords into human
  * readable messages.
  */
-export type ErrorHandler = (normalizedErrors: InstanceOutput, instance: JsonNode, localization: Localization, resolver: AST | ErrorResolver) => ErrorObject[];
+export type ErrorHandler = (normalizedErrors: InstanceOutput, instance: JsonNode, localization: Localization, resolver: ErrorResolver) => ErrorObject[];
 
 /**
  * Converts the normalized error format to human readable errors. It's used to

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -140,16 +140,27 @@ export const evaluateSchema: (schemaLocation: string, instance: JsonNode, contex
 export const addErrorHandler: (handler: ErrorHandler) => void;
 
 /**
+ * Provides access to compiled keyword values and sibling keyword values for error
+ */
+export type ErrorResolver = {
+  getCompiledKeywordValue: (schemaLocation: string) => unknown;
+  getSiblingKeywordValue: (
+    schemaLocation: string,
+    siblingKeywordUri: string
+  ) => { keywordLocation: string; keywordValue: unknown } | undefined; 
+};
+
+/**
  * A function that transforms normalized errors for one or more keywords into human
  * readable messages.
  */
-export type ErrorHandler = (normalizedErrors: InstanceOutput, instance: JsonNode, localization: Localization) => Promise<ErrorObject[]>;
+export type ErrorHandler = (normalizedErrors: InstanceOutput, instance: JsonNode, localization: Localization, resolver?: ErrorResolver) => ErrorObject[];
 
 /**
  * Converts the normalized error format to human readable errors. It's used to
  * build errors in applicator error handlers.
  */
-export const getErrors: (normalizedErrors: NormalizedOutput, instance: JsonNode, localization: Localization) => Promise<ErrorObject[]>;
+export const getErrors: (normalizedErrors: NormalizedOutput, instance: JsonNode, localization: Localization, resolver?: ErrorResolver) => ErrorObject[];
 
 export type { Localization };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -154,13 +154,13 @@ export type ErrorResolver = {
  * A function that transforms normalized errors for one or more keywords into human
  * readable messages.
  */
-export type ErrorHandler = (normalizedErrors: InstanceOutput, instance: JsonNode, localization: Localization, resolver: ErrorResolver) => ErrorObject[];
+export type ErrorHandler = (normalizedErrors: InstanceOutput, instance: JsonNode, localization: Localization, resolver: AST | ErrorResolver) => ErrorObject[];
 
 /**
  * Converts the normalized error format to human readable errors. It's used to
  * build errors in applicator error handlers.
  */
-export const getErrors: (normalizedErrors: NormalizedOutput, instance: JsonNode, localization: Localization, resolver: ErrorResolver) => ErrorObject[];
+export const getErrors: (normalizedErrors: NormalizedOutput, instance: JsonNode, localization: Localization, astOrResolver: AST | ErrorResolver) => ErrorObject[];
 
 export type { Localization };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -147,7 +147,7 @@ export type ErrorResolver = {
   getSiblingKeywordValue: (
     schemaLocation: string,
     siblingKeywordUri: string
-  ) => { keywordLocation: string; keywordValue: unknown } | undefined; 
+  ) => { keywordLocation: string; keywordValue: unknown } | undefined;
 };
 
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -140,27 +140,16 @@ export const evaluateSchema: (schemaLocation: string, instance: JsonNode, contex
 export const addErrorHandler: (handler: ErrorHandler) => void;
 
 /**
- * Provides access to compiled keyword values and sibling keyword values for error
- */
-export type ErrorResolver = {
-  getCompiledKeywordValue: (schemaLocation: string) => unknown;
-  getSiblingKeywordValue: (
-    schemaLocation: string,
-    siblingKeywordUri: string
-  ) => { keywordLocation: string; keywordValue: unknown } | undefined;
-};
-
-/**
  * A function that transforms normalized errors for one or more keywords into human
  * readable messages.
  */
-export type ErrorHandler = (normalizedErrors: InstanceOutput, instance: JsonNode, localization: Localization, resolver: ErrorResolver) => ErrorObject[];
+export type ErrorHandler = (normalizedErrors: InstanceOutput, instance: JsonNode, localization: Localization, ast: AST) => ErrorObject[];
 
 /**
  * Converts the normalized error format to human readable errors. It's used to
  * build errors in applicator error handlers.
  */
-export const getErrors: (normalizedErrors: NormalizedOutput, instance: JsonNode, localization: Localization, astOrResolver: AST | ErrorResolver) => ErrorObject[];
+export const getErrors: (normalizedErrors: NormalizedOutput, instance: JsonNode, localization: Localization, ast: AST) => ErrorObject[];
 
 export type { Localization };
 

--- a/src/json-schema-errors.js
+++ b/src/json-schema-errors.js
@@ -16,11 +16,11 @@ import { JsonSchemaErrorsOutputPlugin } from "./output-plugin.js";
 /** @type API.jsonSchemaErrors */
 export const jsonSchemaErrors = async (errorOutput, schemaUri, instance, options = {}) => {
   const rootInstance = Instance.fromJs(instance);
-  const [normalizedErrors, localization] = await Promise.all([
+  const [{ normalizedErrors, ast }, localization] = await Promise.all([
     normalizedOutput(rootInstance, errorOutput, schemaUri),
     Localization.forLocale(options.locale ?? "en-US")
   ]);
-  return await getErrors(normalizedErrors, rootInstance, localization);
+  return getErrors(normalizedErrors, rootInstance, localization, createErrorResolver(ast));
 };
 
 /** @type Record<string, API.NormalizationHandler> */
@@ -31,12 +31,15 @@ export const setNormalizationHandler = (schemaUri, handler) => {
   normalizationHandlers[schemaUri] = handler;
 };
 
-/** @type (value: JsonNode, errorOutput: API.OutputUnit, subjectUri: string) => Promise<API.NormalizedOutput> */
+/** @type (value: JsonNode, errorOutput: API.OutputUnit, subjectUri: string) => Promise<{ normalizedErrors: API.NormalizedOutput; ast: AST }>} */
 async function normalizedOutput(value, errorOutput, subjectUri) {
   const schema = await getSchema(subjectUri);
   const errorIndex = await constructErrorIndex(errorOutput, schema);
   const { schemaUri, ast } = await compile(schema);
-  return evaluateSchema(schemaUri, value, { ast, errorIndex, plugins: [...ast.plugins] });
+  return { 
+    normalizedErrors: evaluateSchema(schemaUri, value, { ast, errorIndex, plugins: [...ast.plugins] }), 
+    ast 
+  };
 }
 
 /** @type (outputUnit: API.OutputUnit, schema: Browser<SchemaDocument>, errorIndex?: API.ErrorIndex) => Promise<API.ErrorIndex> */
@@ -181,20 +184,40 @@ export const addErrorHandler = (errorHandler) => {
 };
 
 /** @type API.getErrors */
-export const getErrors = async (normalizedErrors, rootInstance, localization) => {
+export const getErrors = (normalizedErrors, rootInstance, localization, resolver) => {
   /** @type API.ErrorObject[] */
   const errors = [];
+
+  resolver ??= {
+    getCompiledKeywordValue: () => {
+      throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
+    },
+    getSiblingKeywordValue: () => {
+      throw new Error("Missing resolver.getSiblingKeywordValue in error handler context");
+    }
+  };
 
   for (const instanceLocation in normalizedErrors) {
     const instance = /** @type JsonNode */ (Instance.get(instanceLocation, rootInstance));
     for (const errorHandler of errorHandlers) {
-      const errorObject = await errorHandler(normalizedErrors[instanceLocation], instance, localization);
+      const errorObject = errorHandler(normalizedErrors[instanceLocation], instance, localization, resolver);
       errors.push(...errorObject);
     }
   }
 
   return errors;
 };
+
+/**
+ * @param {AST} ast
+ * @returns {API.ErrorResolver}
+ */
+const createErrorResolver = (ast) => ({
+  getCompiledKeywordValue: (schemaLocation) => getCompiledKeywordValue(ast, schemaLocation),
+  getSiblingKeywordValue: (schemaLocation, siblingKeywordUri) => {
+    return getSiblingKeywordValue(ast, schemaLocation, siblingKeywordUri);
+  }
+});
 
 /**
  * @param {AST} ast
@@ -288,7 +311,7 @@ const evaluateCompiledSchema = async (compiledSchema, instance, options = {}) =>
   } else {
     return {
       valid,
-      errors: await getErrors(outputPlugin.output, jsonNode, localization)
+      errors: getErrors(outputPlugin.output, jsonNode, localization, createErrorResolver(compiledSchema.ast))
     };
   }
 };

--- a/src/json-schema-errors.js
+++ b/src/json-schema-errors.js
@@ -207,7 +207,7 @@ export const getCompiledKeywordValue = (ast, schemaLocation) => {
 };
 
 /** @type (ast: AST, schemaLocation: string, siblingKeywordUri: string) => string | undefined */
-export const getSiblingKeywordValue = (ast, schemaLocation, siblingKeywordUri) => {
+export const getSiblingKeywordLocation = (ast, schemaLocation, siblingKeywordUri) => {
   const parentNode = getParentNode(ast, schemaLocation);
   if (!Array.isArray(parentNode)) {
     return undefined;

--- a/src/json-schema-errors.js
+++ b/src/json-schema-errors.js
@@ -188,15 +188,6 @@ export const getErrors = (normalizedErrors, rootInstance, localization, resolver
   /** @type API.ErrorObject[] */
   const errors = [];
 
-  resolver ??= {
-    getCompiledKeywordValue: () => {
-      throw new Error("Missing resolver.getCompiledKeywordValue in error handler context");
-    },
-    getSiblingKeywordValue: () => {
-      throw new Error("Missing resolver.getSiblingKeywordValue in error handler context");
-    }
-  };
-
   for (const instanceLocation in normalizedErrors) {
     const instance = /** @type JsonNode */ (Instance.get(instanceLocation, rootInstance));
     for (const errorHandler of errorHandlers) {

--- a/src/json-schema-errors.js
+++ b/src/json-schema-errors.js
@@ -178,9 +178,9 @@ export const getErrors = (normalizedErrors, rootInstance, localization, astOrRes
   /** @type API.ErrorObject[] */
   const errors = [];
 
-  /** @type API.ErrorResolver | AST */
+  /** @type API.ErrorResolver */
   const resolver = "getCompiledKeywordValue" in astOrResolver
-    ? astOrResolver
+    ? /** @type API.ErrorResolver */ (astOrResolver)
     : {
         getCompiledKeywordValue: (schemaLocation) => getCompiledKeywordValue(astOrResolver, schemaLocation),
         getSiblingKeywordValue: (schemaLocation, siblingKeywordUri) => getSiblingKeywordValue(astOrResolver, schemaLocation, siblingKeywordUri)
@@ -197,51 +197,32 @@ export const getErrors = (normalizedErrors, rootInstance, localization, astOrRes
   return errors;
 };
 
-/**
- * @param {AST} ast
- * @param {string} schemaLocation
- * @returns {unknown}
- */
-const getCompiledKeywordValue = (ast, schemaLocation) => {
+/** @type (ast: AST, schemaLocation: string) => unknown */
+const getParentNode = (ast, schemaLocation) => {
   const parentLocation = schemaLocation.replace(/\/[^/]+$/, "");
-  const parentNode = ast[parentLocation];
-  if (!Array.isArray(parentNode)) {
-    return undefined;
-  }
-
-  for (const [, keywordLocation, keywordValue] of parentNode) {
-    if (keywordLocation === schemaLocation) {
-      return keywordValue;
-    }
-  }
-
-  return undefined;
+  return ast[parentLocation];
 };
 
-/**
- * @param {AST} ast
- * @param {string} schemaLocation
- * @param {string} siblingKeywordUri
- * @returns {{ keywordLocation: string; keywordValue: unknown } | undefined}
- */
-const getSiblingKeywordValue = (ast, schemaLocation, siblingKeywordUri) => {
-  const parentLocation = schemaLocation.replace(/\/[^/]+$/, "");
-  const parentNode = ast[parentLocation];
-
+/** @type (ast: AST, schemaLocation: string) => unknown */
+const getCompiledKeywordValue = (ast, schemaLocation) => {
+  const parentNode = getParentNode(ast, schemaLocation);
   if (!Array.isArray(parentNode)) {
     return undefined;
   }
 
-  for (const [keywordUri, keywordLocation, keywordValue] of parentNode) {
-    if (keywordUri === siblingKeywordUri) {
-      return {
-        keywordLocation,
-        keywordValue
-      };
-    }
+  const node = parentNode.find(([, keywordLocation]) => keywordLocation === schemaLocation);
+  return node?.[2];
+};
+
+/** @type (ast: AST, schemaLocation: string, siblingKeywordUri: string) => { keywordLocation: string; keywordValue: unknown } | undefined */
+const getSiblingKeywordValue = (ast, schemaLocation, siblingKeywordUri) => {
+  const parentNode = getParentNode(ast, schemaLocation);
+  if (!Array.isArray(parentNode)) {
+    return undefined;
   }
 
-  return undefined;
+  const node = parentNode.find(([keywordUri]) => keywordUri === siblingKeywordUri);
+  return (!node) ? undefined : { keywordLocation: node[1], keywordValue: node[2] };
 };
 
 /**

--- a/src/json-schema-errors.js
+++ b/src/json-schema-errors.js
@@ -9,7 +9,7 @@ import { JsonSchemaErrorsOutputPlugin } from "./output-plugin.js";
 /**
  * @import * as API from "./index.d.ts"
  * @import { Browser } from "@hyperjump/browser";
- * @import { AST, SchemaDocument, CompiledSchema } from "@hyperjump/json-schema/experimental";
+ * @import { AST, SchemaDocument, CompiledSchema, Node } from "@hyperjump/json-schema/experimental";
  * @import { JsonNode } from "@hyperjump/json-schema/instance/experimental"
  */
 
@@ -19,7 +19,11 @@ export const jsonSchemaErrors = async (errorOutput, schemaUri, instance, options
   const schema = await getSchema(schemaUri);
   const errorIndex = await constructErrorIndex(errorOutput, schema);
   const { schemaUri: compiledSchemaUri, ast } = await compile(schema);
-  const normalizedErrors = evaluateSchema(compiledSchemaUri, rootInstance, { ast, errorIndex, plugins: [...ast.plugins] });
+  const normalizedErrors = evaluateSchema(compiledSchemaUri, rootInstance, {
+    ast,
+    errorIndex,
+    plugins: [...ast.plugins]
+  });
   const localization = await Localization.forLocale(options.locale ?? "en-US");
   return getErrors(normalizedErrors, rootInstance, localization, ast);
 };
@@ -64,11 +68,7 @@ const constructErrorIndex = async (outputUnit, schema, errorIndex = {}) => {
   return errorIndex;
 };
 
-/**
- * @param {Browser} schema
- * @param {string} keywordLocation
- * @returns {Promise<string>}
- */
+/** @type (schema: Browser, keywordLocation: string) => Promise<string> */
 async function toAbsoluteKeywordLocation(schema, keywordLocation) {
   if (keywordLocation.startsWith("#")) {
     keywordLocation = keywordLocation.slice(1);
@@ -189,7 +189,7 @@ export const getErrors = (normalizedErrors, rootInstance, localization, ast) => 
   return errors;
 };
 
-/** @type (ast: AST, schemaLocation: string) => unknown */
+/** @type (ast: AST, schemaLocation: string) => Node<unknown>[] | boolean | undefined */
 const getParentNode = (ast, schemaLocation) => {
   const parentLocation = schemaLocation.replace(/\/[^/]+$/, "");
   return ast[parentLocation];
@@ -198,23 +198,31 @@ const getParentNode = (ast, schemaLocation) => {
 /** @type (ast: AST, schemaLocation: string) => unknown */
 export const getCompiledKeywordValue = (ast, schemaLocation) => {
   const parentNode = getParentNode(ast, schemaLocation);
-  if (!Array.isArray(parentNode)) {
-    return undefined;
+  if (typeof parentNode === "boolean") {
+    return parentNode;
   }
 
-  const node = parentNode.find(([, keywordLocation]) => keywordLocation === schemaLocation);
-  return node?.[2];
+  const node = parentNode?.find(([, keywordLocation]) => keywordLocation === schemaLocation);
+  if (!node) {
+    throw Error("AST node not found");
+  }
+
+  return node[2];
 };
 
-/** @type (ast: AST, schemaLocation: string, siblingKeywordUri: string) => string | undefined */
+/** @type (ast: AST, schemaLocation: string, siblingKeywordUri: string) => string */
 export const getSiblingKeywordLocation = (ast, schemaLocation, siblingKeywordUri) => {
-  const parentNode = getParentNode(ast, schemaLocation);
-  if (!Array.isArray(parentNode)) {
-    return undefined;
+  let parentNode = getParentNode(ast, schemaLocation);
+  if (typeof parentNode === "boolean") {
+    parentNode = undefined;
   }
 
-  const node = parentNode.find(([keywordUri]) => keywordUri === siblingKeywordUri);
-  return node?.[1];
+  const node = parentNode?.find(([keywordUri]) => keywordUri === siblingKeywordUri);
+  if (!node) {
+    throw Error("AST node not found");
+  }
+
+  return node[1];
 };
 
 /**

--- a/src/json-schema-errors.js
+++ b/src/json-schema-errors.js
@@ -9,7 +9,7 @@ import { JsonSchemaErrorsOutputPlugin } from "./output-plugin.js";
 /**
  * @import * as API from "./index.d.ts"
  * @import { Browser } from "@hyperjump/browser";
- * @import { SchemaDocument, CompiledSchema } from "@hyperjump/json-schema/experimental";
+ * @import { AST, SchemaDocument, CompiledSchema } from "@hyperjump/json-schema/experimental";
  * @import { JsonNode } from "@hyperjump/json-schema/instance/experimental"
  */
 
@@ -194,6 +194,53 @@ export const getErrors = async (normalizedErrors, rootInstance, localization) =>
   }
 
   return errors;
+};
+
+/**
+ * @param {AST} ast
+ * @param {string} schemaLocation
+ * @returns {unknown}
+ */
+const getCompiledKeywordValue = (ast, schemaLocation) => {
+  const parentLocation = schemaLocation.replace(/\/[^/]+$/, "");
+  const parentNode = ast[parentLocation];
+  if (!Array.isArray(parentNode)) {
+    return undefined;
+  }
+
+  for (const [, keywordLocation, keywordValue] of parentNode) {
+    if (keywordLocation === schemaLocation) {
+      return keywordValue;
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * @param {AST} ast
+ * @param {string} schemaLocation
+ * @param {string} siblingKeywordUri
+ * @returns {{ keywordLocation: string; keywordValue: unknown } | undefined}
+ */
+const getSiblingKeywordValue = (ast, schemaLocation, siblingKeywordUri) => {
+  const parentLocation = schemaLocation.replace(/\/[^/]+$/, "");
+  const parentNode = ast[parentLocation];
+
+  if (!Array.isArray(parentNode)) {
+    return undefined;
+  }
+
+  for (const [keywordUri, keywordLocation, keywordValue] of parentNode) {
+    if (keywordUri === siblingKeywordUri) {
+      return {
+        keywordLocation,
+        keywordValue
+      };
+    }
+  }
+
+  return undefined;
 };
 
 /**

--- a/src/json-schema-errors.js
+++ b/src/json-schema-errors.js
@@ -36,9 +36,9 @@ async function normalizedOutput(value, errorOutput, subjectUri) {
   const schema = await getSchema(subjectUri);
   const errorIndex = await constructErrorIndex(errorOutput, schema);
   const { schemaUri, ast } = await compile(schema);
-  return { 
-    normalizedErrors: evaluateSchema(schemaUri, value, { ast, errorIndex, plugins: [...ast.plugins] }), 
-    ast 
+  return {
+    normalizedErrors: evaluateSchema(schemaUri, value, { ast, errorIndex, plugins: [...ast.plugins] }),
+    ast
   };
 }
 

--- a/src/json-schema-errors.js
+++ b/src/json-schema-errors.js
@@ -174,22 +174,14 @@ export const addErrorHandler = (errorHandler) => {
 };
 
 /** @type API.getErrors */
-export const getErrors = (normalizedErrors, rootInstance, localization, astOrResolver) => {
+export const getErrors = (normalizedErrors, rootInstance, localization, ast) => {
   /** @type API.ErrorObject[] */
   const errors = [];
-
-  /** @type API.ErrorResolver */
-  const resolver = "getCompiledKeywordValue" in astOrResolver
-    ? /** @type API.ErrorResolver */ (astOrResolver)
-    : {
-        getCompiledKeywordValue: (schemaLocation) => getCompiledKeywordValue(astOrResolver, schemaLocation),
-        getSiblingKeywordValue: (schemaLocation, siblingKeywordUri) => getSiblingKeywordValue(astOrResolver, schemaLocation, siblingKeywordUri)
-      };
 
   for (const instanceLocation in normalizedErrors) {
     const instance = /** @type JsonNode */ (Instance.get(instanceLocation, rootInstance));
     for (const errorHandler of errorHandlers) {
-      const errorObject = errorHandler(normalizedErrors[instanceLocation], instance, localization, resolver);
+      const errorObject = errorHandler(normalizedErrors[instanceLocation], instance, localization, ast);
       errors.push(...errorObject);
     }
   }
@@ -204,7 +196,7 @@ const getParentNode = (ast, schemaLocation) => {
 };
 
 /** @type (ast: AST, schemaLocation: string) => unknown */
-const getCompiledKeywordValue = (ast, schemaLocation) => {
+export const getCompiledKeywordValue = (ast, schemaLocation) => {
   const parentNode = getParentNode(ast, schemaLocation);
   if (!Array.isArray(parentNode)) {
     return undefined;
@@ -214,15 +206,15 @@ const getCompiledKeywordValue = (ast, schemaLocation) => {
   return node?.[2];
 };
 
-/** @type (ast: AST, schemaLocation: string, siblingKeywordUri: string) => { keywordLocation: string; keywordValue: unknown } | undefined */
-const getSiblingKeywordValue = (ast, schemaLocation, siblingKeywordUri) => {
+/** @type (ast: AST, schemaLocation: string, siblingKeywordUri: string) => string | undefined */
+export const getSiblingKeywordValue = (ast, schemaLocation, siblingKeywordUri) => {
   const parentNode = getParentNode(ast, schemaLocation);
   if (!Array.isArray(parentNode)) {
     return undefined;
   }
 
   const node = parentNode.find(([keywordUri]) => keywordUri === siblingKeywordUri);
-  return (!node) ? undefined : { keywordLocation: node[1], keywordValue: node[2] };
+  return node?.[1];
 };
 
 /**

--- a/src/json-schema-errors.js
+++ b/src/json-schema-errors.js
@@ -16,11 +16,12 @@ import { JsonSchemaErrorsOutputPlugin } from "./output-plugin.js";
 /** @type API.jsonSchemaErrors */
 export const jsonSchemaErrors = async (errorOutput, schemaUri, instance, options = {}) => {
   const rootInstance = Instance.fromJs(instance);
-  const [{ normalizedErrors, ast }, localization] = await Promise.all([
-    normalizedOutput(rootInstance, errorOutput, schemaUri),
-    Localization.forLocale(options.locale ?? "en-US")
-  ]);
-  return getErrors(normalizedErrors, rootInstance, localization, createErrorResolver(ast));
+  const schema = await getSchema(schemaUri);
+  const errorIndex = await constructErrorIndex(errorOutput, schema);
+  const { schemaUri: compiledSchemaUri, ast } = await compile(schema);
+  const normalizedErrors = evaluateSchema(compiledSchemaUri, rootInstance, { ast, errorIndex, plugins: [...ast.plugins] });
+  const localization = await Localization.forLocale(options.locale ?? "en-US");
+  return getErrors(normalizedErrors, rootInstance, localization, ast);
 };
 
 /** @type Record<string, API.NormalizationHandler> */
@@ -30,17 +31,6 @@ const normalizationHandlers = {};
 export const setNormalizationHandler = (schemaUri, handler) => {
   normalizationHandlers[schemaUri] = handler;
 };
-
-/** @type (value: JsonNode, errorOutput: API.OutputUnit, subjectUri: string) => Promise<{ normalizedErrors: API.NormalizedOutput; ast: AST }>} */
-async function normalizedOutput(value, errorOutput, subjectUri) {
-  const schema = await getSchema(subjectUri);
-  const errorIndex = await constructErrorIndex(errorOutput, schema);
-  const { schemaUri, ast } = await compile(schema);
-  return {
-    normalizedErrors: evaluateSchema(schemaUri, value, { ast, errorIndex, plugins: [...ast.plugins] }),
-    ast
-  };
-}
 
 /** @type (outputUnit: API.OutputUnit, schema: Browser<SchemaDocument>, errorIndex?: API.ErrorIndex) => Promise<API.ErrorIndex> */
 const constructErrorIndex = async (outputUnit, schema, errorIndex = {}) => {
@@ -184,9 +174,17 @@ export const addErrorHandler = (errorHandler) => {
 };
 
 /** @type API.getErrors */
-export const getErrors = (normalizedErrors, rootInstance, localization, resolver) => {
+export const getErrors = (normalizedErrors, rootInstance, localization, astOrResolver) => {
   /** @type API.ErrorObject[] */
   const errors = [];
+
+  /** @type API.ErrorResolver | AST */
+  const resolver = "getCompiledKeywordValue" in astOrResolver
+    ? astOrResolver
+    : {
+        getCompiledKeywordValue: (schemaLocation) => getCompiledKeywordValue(astOrResolver, schemaLocation),
+        getSiblingKeywordValue: (schemaLocation, siblingKeywordUri) => getSiblingKeywordValue(astOrResolver, schemaLocation, siblingKeywordUri)
+      };
 
   for (const instanceLocation in normalizedErrors) {
     const instance = /** @type JsonNode */ (Instance.get(instanceLocation, rootInstance));
@@ -198,17 +196,6 @@ export const getErrors = (normalizedErrors, rootInstance, localization, resolver
 
   return errors;
 };
-
-/**
- * @param {AST} ast
- * @returns {API.ErrorResolver}
- */
-const createErrorResolver = (ast) => ({
-  getCompiledKeywordValue: (schemaLocation) => getCompiledKeywordValue(ast, schemaLocation),
-  getSiblingKeywordValue: (schemaLocation, siblingKeywordUri) => {
-    return getSiblingKeywordValue(ast, schemaLocation, siblingKeywordUri);
-  }
-});
 
 /**
  * @param {AST} ast
@@ -302,7 +289,7 @@ const evaluateCompiledSchema = async (compiledSchema, instance, options = {}) =>
   } else {
     return {
       valid,
-      errors: getErrors(outputPlugin.output, jsonNode, localization, createErrorResolver(compiledSchema.ast))
+      errors: getErrors(outputPlugin.output, jsonNode, localization, compiledSchema.ast)
     };
   }
 };


### PR DESCRIPTION
This PR removes async schema value lookups from the error formatting path and makes getErrors synchronous by resolving keyword values from the compiled AST to using it so it can be used in `@hyperjump/json-schema` as we need here (https://github.com/hyperjump-io/json-schema-errors/issues/204).

I replaced async schema reads with two AST resolver functions: getCompiledKeywordValue() for normal keyword lookups by schemaLocation, and getSiblingKeywordValue() for sibling keywords in the same parent node (like draft-04 min/max exclusivity and contains min/max contains). Then getErrors passes this resolver to handlers, so the whole error handling path is synchronous and no longer depends on await getSchema().

getErrors now passes an AST resolver to handlers, including recursive ones, and sibling-dependent keywords use sibling lookup from the same parent AST node. I also adjusted handlers for compiled value shapes (like regex, draft-04 tuples, and const/enum JSON strings), then updated types. All tests are still passing leaves us with the same behavior.