### PR TITLE
feat: allow overriding and removing error handlers

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -137,7 +137,20 @@ export type NormalizedOutput = {
  */
 export const evaluateSchema: (schemaLocation: string, instance: JsonNode, context: EvaluationContext) => NormalizedOutput;
 
-export const addErrorHandler: (handler: ErrorHandler) => void;
+/**
+ * Sets an error handler for the given URI. If an error handler already exists
+ * for this URI, it will be replaced with the new handler.
+ *
+ * @param errorHandlerUri - A URI for unique indentification of error handler
+ * @param handler
+ */
+export const setErrorHandler: (errorHandlerUri: string, handler: ErrorHandler) => void;
+
+/**
+ * Removes the error handler registered for the given URI.
+ * @param errorHandlerUri
+ */
+export const removeErrorHandler: (errorHandlerUri: string) => void;
 
 /**
  * A function that transforms normalized errors for one or more keywords into human

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { addErrorHandler, setNormalizationHandler } from "./json-schema-errors.js";
+import { setErrorHandler, setNormalizationHandler } from "./json-schema-errors.js";
 
 // Normalization Handlers
 import additionalItemsNormalizationHandler from "./normalization-handlers/draft-04/additionalItems.js";
@@ -146,33 +146,34 @@ setNormalizationHandler("https://json-schema.org/keyword/uniqueItems", uniqueIte
 setNormalizationHandler("https://json-schema.org/keyword/unknown", unknownNormalizationHandler);
 setNormalizationHandler("https://json-schema.org/keyword/writeOnly", writeOnlyNormalizationHandler);
 
-addErrorHandler(anyOfErrorHandler);
-addErrorHandler(booleanSchemaErrorHandler);
-addErrorHandler(containsErrorHandler);
-addErrorHandler(dependenciesErrorHandler);
-addErrorHandler(formatErrorHandler);
-addErrorHandler(maximumErrorHandler);
-addErrorHandler(maxItemsErrorHandler);
-addErrorHandler(maxLengthErrorHandler);
-addErrorHandler(maxPropertiesErrorHandler);
-addErrorHandler(minimumErrorHandler);
-addErrorHandler(minItemsErrorHandler);
-addErrorHandler(minLengthErrorHandler);
-addErrorHandler(minPropertiesErrorHandler);
-addErrorHandler(multipleOfErrorHandler);
-addErrorHandler(notErrorHandler);
-addErrorHandler(oneOfErrorHandler);
-addErrorHandler(patternErrorHandler);
-addErrorHandler(requiredErrorHandler);
-addErrorHandler(typeConstEnumErrorHandler);
-addErrorHandler(uniqueItemsErrorHandler);
-addErrorHandler(unknownErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/anyOf", anyOfErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/boolean-schema", booleanSchemaErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/contains", containsErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/dependencies", dependenciesErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/format", formatErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/maximum", maximumErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/maxItems", maxItemsErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/maxLength", maxLengthErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/maxProperties", maxPropertiesErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/minimum", minimumErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/minItems", minItemsErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/minLength", minLengthErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/minProperties", minPropertiesErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/multipleOf", multipleOfErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/not", notErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/oneOf", oneOfErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/pattern", patternErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/required", requiredErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/typeConstEnum", typeConstEnumErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/uniqueItems", uniqueItemsErrorHandler);
+setErrorHandler("https://hyperjump.io/error-handler/unknown", unknownErrorHandler);
 
 export {
-  addErrorHandler,
   evaluateSchema,
   getErrors,
   jsonSchemaErrors,
+  removeErrorHandler,
+  setErrorHandler,
   setNormalizationHandler,
   validate
 } from "./json-schema-errors.js";

--- a/src/json-schema-errors.js
+++ b/src/json-schema-errors.js
@@ -165,12 +165,17 @@ const mergeOutput = (a, b) => {
   }
 };
 
-/** @type API.ErrorHandler[] */
-const errorHandlers = [];
+/** @type Record<string, API.ErrorHandler> */
+const errorHandlers = {};
 
-/** @type API.addErrorHandler */
-export const addErrorHandler = (errorHandler) => {
-  errorHandlers.push(errorHandler);
+/** @type API.setErrorHandler */
+export const setErrorHandler = (errorHandlerUri, errorHandler) => {
+  errorHandlers[errorHandlerUri] = errorHandler;
+};
+
+/** @type API.removeErrorHandler */
+export const removeErrorHandler = (errorHandlerUri) => {
+  delete errorHandlers[errorHandlerUri];
 };
 
 /** @type API.getErrors */
@@ -180,8 +185,8 @@ export const getErrors = (normalizedErrors, rootInstance, localization, ast) => 
 
   for (const instanceLocation in normalizedErrors) {
     const instance = /** @type JsonNode */ (Instance.get(instanceLocation, rootInstance));
-    for (const errorHandler of errorHandlers) {
-      const errorObject = errorHandler(normalizedErrors[instanceLocation], instance, localization, ast);
+    for (const errorHandlerUri in errorHandlers) {
+      const errorObject = errorHandlers[errorHandlerUri](normalizedErrors[instanceLocation], instance, localization, ast);
       errors.push(...errorObject);
     }
   }


### PR DESCRIPTION
## Description

This PR introduces change that will allow users to override default error handlers and to remove or replace existing error handlers.
Closes : #225 

### Changes made
- Introduced `setErrorHandler(uri, handler)` which registers error handlers by URI, allowing replacement by calling it again with the same URI.
- Added `removeErrorHandler(uri)` for removal of a handler.
- Error handler registry signature from an  array to a object keyed by URI, consistent with `normalizationHandlers`.