### PR TITLE
corrected a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ import type { ErrorObject } from "@hyperjump/json-schema-errors";
 const KEYWORD_URI = "https://example.com/keyword/startsWith";
 
 setNormalizationHandler(KEYWORD_URI, {
-  evalute() {
+  evaluate() {
     // Only applicator keywords need to return a value
   }
 });


### PR DESCRIPTION
Found a typo while reading the codebase:

- `evalute` → `evaluate` in README custom keyword example (would cause silent failures for users copying this)