### PR TITLE
test: add edge case coverage for uniqueItems with objects and booleans

### DIFF
--- a/src/test-suite/tests/uniqueItems.json
+++ b/src/test-suite/tests/uniqueItems.json
@@ -29,6 +29,44 @@
       },
       "instance": ["foo", "bar"],
       "errors": []
+    },
+    {
+      "description": "uniqueItems with duplicate objects",
+      "schema": { "uniqueItems": true },
+      "instance": [{ "a": 1 }, { "a": 1 }, { "b": 2 }],
+      "errors": [
+        {
+          "messageId": "uniqueItems-message",
+          "messageParams": {},
+          "instanceLocation": "#/0",
+          "schemaLocations": ["#/uniqueItems"]
+        },
+        {
+          "messageId": "uniqueItems-message",
+          "messageParams": {},
+          "instanceLocation": "#/1",
+          "schemaLocations": ["#/uniqueItems"]
+        }
+      ]
+    },
+    {
+      "description": "uniqueItems with duplicate booleans",
+      "schema": { "uniqueItems": true },
+      "instance": [true, true],
+      "errors": [
+        {
+          "messageId": "uniqueItems-message",
+          "messageParams": {},
+          "instanceLocation": "#/0",
+          "schemaLocations": ["#/uniqueItems"]
+        },
+        {
+          "messageId": "uniqueItems-message",
+          "messageParams": {},
+          "instanceLocation": "#/1",
+          "schemaLocations": ["#/uniqueItems"]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
The `uniqueItems` error handler uses `json-stringify-deterministic` to compare array items, but the test suite only covered string values.

Added test cases for:

Duplicate objects (`[{"a":1},{"a":1}]`) -- exercises the JSON stringify path for nested values
Duplicate booleans (`[true, true]`) -- exercises primitive non-string comparison

Both new cases pass, confirming the handler works correctly for these types. 